### PR TITLE
19364_dina_service_get_reference_by_natural_id

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/DinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/DinaService.java
@@ -110,6 +110,19 @@ public abstract class DinaService<E extends DinaEntity> {
   }
 
   /**
+   * Returns a reference to an entity that should exist without actually loading
+   * it. Useful to set relationships without loading the entity and should be used instead of
+   * findOne.
+   * 
+   * @param naturalId   - id of entity
+   * @param entityClass - class of entity
+   * @return the matched reference
+   */
+  public <T> T findOneReferenceByNaturalId(Class<T> entityClass, Object naturalId) {
+    return baseDAO.getReferenceByNaturalId(entityClass, naturalId);
+  }
+
+  /**
    * Returns a new instance of a {@link JpaCriteriaQueryFactory} for crnk JPA data
    * access.
    */

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/DinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/DinaService.java
@@ -111,10 +111,9 @@ public abstract class DinaService<E extends DinaEntity> {
 
   /**
    * Returns a reference to an entity that should exist without actually loading
-   * it. Useful to set relationships without loading the entity and should be used instead of
-   * findOne.
+   * it. Useful to set relationships without loading the entity instead of findOne.
    * 
-   * @param naturalId   - id of entity
+   * @param naturalId   - natural id of entity
    * @param entityClass - class of entity
    * @return the matched reference
    */


### PR DESCRIPTION
Adds findOneReferenceByNaturalId to Dina Service.

This is a delegater method only and can be considered tested through the base dao.