### PR TITLE
19377 dina repo meta info

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -45,7 +45,8 @@ import lombok.SneakyThrows;
 
 /**
  * JSONAPI repository that interfaces using DTOs, and uses JPA entities
- * internally.
+ * internally. Sparse fields sets are handled by the underlying Crnk
+ * ResourceRepository.
  * 
  * @param <D>
  *              - Dto type

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -139,9 +139,6 @@ public class DinaRepository<D, E extends DinaEntity>
       .map(e -> dinaMapper.toDto(e, entityFieldsPerClass, includedRelations))
       .collect(Collectors.toList());
 
-    // Uses an actual count from the database
-    metaInformation.setTotalResourceCount(query.buildExecutor(querySpec).getTotalRowCount());
-
     if (CollectionUtils.isNotEmpty(ids)) {
       String idFieldName = this.resourceRegistry
         .findEntry(resourceClass)
@@ -152,6 +149,9 @@ public class DinaRepository<D, E extends DinaEntity>
         .filter(dto -> ids.contains(PropertyUtils.getProperty(dto, idFieldName)))
         .collect(Collectors.toList());
       metaInformation.setTotalResourceCount(Long.valueOf(dtos.size()));
+    } else {
+      // Uses an actual count from the database
+      metaInformation.setTotalResourceCount(query.buildExecutor(querySpec).getTotalRowCount());
     }
 
     return new DefaultResourceList<>(dtos, metaInformation, NO_LINK_INFORMATION);

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -57,6 +57,9 @@ import lombok.SneakyThrows;
 public class DinaRepository<D, E extends DinaEntity>
     implements ResourceRepository<D, Serializable>, ResourceRegistryAware {
 
+  /* Forces CRNK to not display any top-level links. */
+  private static final NoLinkInformation NO_LINK_INFORMATION = new NoLinkInformation();
+
   private final DinaService<E> dinaService;
 
   private final DinaMapper<D, E> dinaMapper;
@@ -151,7 +154,7 @@ public class DinaRepository<D, E extends DinaEntity>
       metaInformation.setTotalResourceCount(Long.valueOf(dtos.size()));
     }
 
-    return new DefaultResourceList<>(dtos, metaInformation, new NoLinkInformation());
+    return new DefaultResourceList<>(dtos, metaInformation, NO_LINK_INFORMATION);
   }
 
   @Override

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -136,6 +136,7 @@ public class DinaRepository<D, E extends DinaEntity>
       .map(e -> dinaMapper.toDto(e, entityFieldsPerClass, includedRelations))
       .collect(Collectors.toList());
 
+    // Uses an actual count from the database
     metaInformation.setTotalResourceCount(query.buildExecutor(querySpec).getTotalRowCount());
 
     if (CollectionUtils.isNotEmpty(ids)) {

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/repository/DinaRepositoryIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/repository/DinaRepositoryIT.java
@@ -259,7 +259,7 @@ public class DinaRepositoryIT {
   }
 
   @Test
-  public void findAll_FilterByIds_ReturnsMetaInformation() {
+  public void findAll_FilterByIds_ReturnsTotalCount() {
     List<Serializable> idList = new ArrayList<>();
 
     for (int i = 0; i < 10; i++) {

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/repository/DinaRepositoryIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/repository/DinaRepositoryIT.java
@@ -41,6 +41,8 @@ import io.crnk.core.queryspec.IncludeRelationSpec;
 import io.crnk.core.queryspec.PathSpec;
 import io.crnk.core.queryspec.QuerySpec;
 import io.crnk.core.queryspec.SortSpec;
+import io.crnk.core.resource.list.ResourceList;
+import io.crnk.core.resource.meta.PagedMetaInformation;
 import lombok.NonNull;
 
 @Transactional
@@ -254,6 +256,40 @@ public class DinaRepositoryIT {
     for (int i = 0; i < expectedDtos.size(); i++) {
       assertEqualsPersonDtos(expectedDtos.get(i), result.get(i), false);
     }
+  }
+
+  @Test
+  public void findAll_FilterByIds_ReturnsMetaInformation() {
+    List<Serializable> idList = new ArrayList<>();
+
+    for (int i = 0; i < 10; i++) {
+      PersonDTO dto = persistPerson();
+      idList.add(dto.getUuid());
+      // Persist extra person not in list
+      persistPerson();
+    }
+
+    ResourceList<PersonDTO> resultList = dinaRepository.findAll(idList, new QuerySpec(PersonDTO.class));
+    PagedMetaInformation metadata = (PagedMetaInformation) resultList.getMeta();
+
+    assertEquals(idList.size(), metadata.getTotalResourceCount());
+  }
+
+  @Test
+  public void findAll_whenPageLimitIsSet_ReturnsTotalCount() {
+    long pageLimit = 10;
+    long totalResouceCount = pageLimit * 2;
+
+    for (int i = 0; i < totalResouceCount; i++) {
+      persistPerson();
+    }
+
+    QuerySpec querySpec = new QuerySpec(PersonDTO.class);
+    querySpec.setLimit(pageLimit);
+
+    ResourceList<PersonDTO> result = dinaRepository.findAll(null, querySpec);
+    PagedMetaInformation metadata = (PagedMetaInformation) result.getMeta();
+    assertEquals(totalResouceCount, metadata.getTotalResourceCount());
   }
 
   @Test


### PR DESCRIPTION
This enables the dina repo to return meta information (total resource count) and exclude top level links during find all requests.

This is a slightly different implementation then stated on the original ticket for the following reason.

Dina repo find all is currently not using the dina service but instead leverages crnks jpa modules. As dina service is not used in this way, adding a DinaService.GetCount would be unnecessary at this time.

We can always change the approach if need be