### PR TITLE
19666_dina_mapper_null_pointer_when_no_resolver_source

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
@@ -146,7 +146,9 @@ public class DinaMapper<D, E> {
 
     mapFieldsToTarget(source, target, selectedFields, ignoreIf);
     mapRelationsToTarget(source, target, selectedFieldPerClass, relations);
-    handlers.get(sourceType).resolveFields(selectedFields, source, target);
+    if (handlers.containsKey(sourceType)) {
+      handlers.get(sourceType).resolveFields(selectedFields, source, target);
+    }
   }
 
   /**


### PR DESCRIPTION
Small bug fix for accessing resolver map before checking for a key.

was causing a null pointer.