### PR TITLE
19783 dina mapper null pointer when no related entity

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
@@ -272,7 +272,12 @@ public class DinaMapper<D, E> {
    *                - map to fill
    */
   private static void parseHandlers(Class<?> clazz, Map<Class<?>, CustomFieldHandler<?, ?>> map) {
-    Class<?> relatedEntity = clazz.getAnnotation(RelatedEntity.class).value();
+    RelatedEntity annotation = clazz.getAnnotation(RelatedEntity.class);
+    if (annotation == null) {
+      return;
+    }
+
+    Class<?> relatedEntity = annotation.value();
 
     if (map.containsKey(clazz) || map.containsKey(relatedEntity)) {
       return;

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
@@ -344,9 +344,9 @@ public class DinaMapper<D, E> {
    * Returns true if the given class has the given field.
    * 
    * @param cls
-   *                     - class to check
-   * @param fieldName-
-   *                     field to check
+   *                    - class to check
+   * @param fieldName
+   *                    - field to check
    * @return true if the given class has the given field.
    */
   private static boolean hasfield(Class<?> cls, String fieldName) {

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMapperTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMapperTest.java
@@ -263,7 +263,7 @@ public class DinaMapperTest {
     assertNull(result.getClassMates());
   }
 
-    @Test
+  @Test
   public void mapperInit_IncorrectResolverReturnTypes_ThrowsIllegalState() {
     assertThrows(
       IllegalStateException.class,
@@ -371,6 +371,10 @@ public class DinaMapperTest {
     // Many to - Relation to test
     @JsonApiRelation
     private List<StudentDto> classMates;
+
+    // Relation with no related entity
+    @JsonApiRelation
+    private NoRelatedEntityDTO noRelatedEntityDTO;
 
     @CustomFieldResolver(fieldName = "customField")
     public String customFieldToDto(Student entity) {
@@ -506,5 +510,18 @@ public class DinaMapperTest {
     public String customFieldToDto(String entity) {
       return null;
     }
+  }
+
+  /**
+   * Relation without a related entity
+   */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static final class NoRelatedEntityDTO {
+
+    private String customField;
+
   }
 }


### PR DESCRIPTION
There are situations where a DTO will have relations that are not present on the entity. 

The changes here will ignore relations that are not present on the entity as they are not mapped anyways.

