### PR TITLE
19814 mapper reflection performance improvements

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
@@ -72,10 +72,9 @@ public class DinaMapper<D, E> {
         fieldsPerClass.put(dto, parseFieldNames(dto));
         fieldsPerClass.put(relatedEntity, parseFieldNames(relatedEntity));
 
-        relationPerClass.put(dto, getRelationFieldNames(dto));
-        relationPerClass.put(relatedEntity, getRelationFieldNames(dto));
+        relationPerClass.put(dto, parseRelationFieldNames(dto));
+        relationPerClass.put(relatedEntity, parseRelationFieldNames(relatedEntity));
       }
-
     }
   }
 
@@ -87,14 +86,12 @@ public class DinaMapper<D, E> {
     if (visited.contains(dto)) {
       return visited;
     }
-
     visited.add(dto);
 
     for (Field f : getRelations(dto)) {
       Class<?> dtoType = isCollection(f.getType()) ? getGenericType(dto, f.getName()) : f.getType();
       parseGrpah(dtoType, visited);
     }
-
     return visited;
   }
 
@@ -338,16 +335,6 @@ public class DinaMapper<D, E> {
   }
 
   /**
-   * Returns a set of field names for a given class.
-   * 
-   * @param cls - class to parse
-   * @return set of field names for a given class.
-   */
-  private static Set<String> parseFieldNames(Class<?> cls) {
-    return Stream.of(cls.getDeclaredFields()).map(Field::getName).collect(Collectors.toSet());
-  }
-
-  /**
    * Returns the resolved type of a fieldname for a given source. If the type is a
    * collection, the first generic type is returned.
    * 
@@ -391,17 +378,25 @@ public class DinaMapper<D, E> {
    * @param cls - class to parse
    * @return JsonApiRelations field names for a given class
    */
-  private static Set<String> getRelationFieldNames(Class<?> cls) {
+  private static Set<String> parseRelationFieldNames(Class<?> cls) {
     return getRelations(cls).stream().map(Field::getName).collect(Collectors.toSet());
+  }
+
+  /**
+   * Returns a set of field names for a given class.
+   * 
+   * @param cls - class to parse
+   * @return set of field names for a given class.
+   */
+  private static Set<String> parseFieldNames(Class<?> cls) {
+    return Stream.of(cls.getDeclaredFields()).map(Field::getName).collect(Collectors.toSet());
   }
 
   /**
    * Returns true if the given class has the given field.
    * 
-   * @param cls
-   *                    - class to check
-   * @param fieldName
-   *                    - field to check
+   * @param cls       - class to check
+   * @param fieldName - field to check
    * @return true if the given class has the given field.
    */
   private boolean hasfield(Class<?> cls, String fieldName) {

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
@@ -287,8 +287,10 @@ public class DinaMapper<D, E> {
 
     Object target = targetType.getDeclaredConstructor().newInstance();
     Set<String> relation = Stream
-      .concat(getRelations(source.getClass()).stream(), getRelations(targetType).stream())
-      .map(Field::getName).collect(Collectors.toSet());
+      .concat(
+        relationPerClass.get(source.getClass()).stream(),
+        relationPerClass.get(targetType).stream())
+      .collect(Collectors.toSet());
     mapSourceToTarget(source, target, fields, relation, visited);
     return target;
   }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
@@ -14,6 +14,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.collect.Sets;
+
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 
@@ -283,11 +285,9 @@ public class DinaMapper<D, E> {
     }
 
     Object target = targetType.getDeclaredConstructor().newInstance();
-    Set<String> relation = Stream
-      .concat(
-        relationPerClass.get(source.getClass()).stream(),
-        relationPerClass.get(targetType).stream())
-      .collect(Collectors.toSet());
+    Set<String> relation = Sets.union(
+      relationPerClass.get(source.getClass()),
+      relationPerClass.get(targetType));
     mapSourceToTarget(source, target, fields, relation, visited);
     return target;
   }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
@@ -60,7 +60,7 @@ public class DinaMapper<D, E> {
   }
 
   private void initMaps(Class<D> dtoClass) {
-    Set<Class<?>> dtoClasses = parseGrpah(dtoClass);
+    Set<Class<?>> dtoClasses = parseGraph(dtoClass);
 
     for (Class<?> dto : dtoClasses) {
       RelatedEntity annotation = dto.getAnnotation(RelatedEntity.class);
@@ -80,11 +80,11 @@ public class DinaMapper<D, E> {
     }
   }
 
-  private Set<Class<?>> parseGrpah(Class<D> dto) {
-    return parseGrpah(dto, new HashSet<>());
+  private Set<Class<?>> parseGraph(Class<D> dto) {
+    return parseGraph(dto, new HashSet<>());
   }
 
-  private Set<Class<?>> parseGrpah(Class<?> dto, Set<Class<?>> visited) {
+  private Set<Class<?>> parseGraph(Class<?> dto, Set<Class<?>> visited) {
     if (visited.contains(dto)) {
       return visited;
     }
@@ -92,7 +92,7 @@ public class DinaMapper<D, E> {
 
     for (Field f : getRelations(dto)) {
       Class<?> dtoType = isCollection(f.getType()) ? getGenericType(dto, f.getName()) : f.getType();
-      parseGrpah(dtoType, visited);
+      parseGraph(dtoType, visited);
     }
     return visited;
   }


### PR DESCRIPTION
Moves a portion of reflective operations for the dina mapper to the initialization of the mapper.

Each mapping request will use initialized maps to track what it needs during the mapping process.