### PR TITLE
Feedback Bug #19939 javax validation error messages are not returned …

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
@@ -188,7 +188,10 @@ public class BaseDAO {
    * @return returns the managed instance the state was merged to.
    */
   public <E> E update(E entity) {
-    return entityManager.merge(entity);
+    E result = entityManager.merge(entity);
+    // Flush here to throw any validation errors:
+    entityManager.flush();
+    return result;
   }
 
   /**

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/jpa/BaseDAOIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/jpa/BaseDAOIT.java
@@ -4,11 +4,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.UUID;
 
 import javax.inject.Inject;
 import javax.transaction.Transactional;
+import javax.validation.ConstraintViolationException;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
@@ -107,6 +109,19 @@ public class BaseDAOIT {
     Department result = baseDAO.findOneByNaturalId(dep.getUuid(), Department.class);
     assertEquals(expectedName, result.getName());
     assertEquals(expectedLocation, result.getLocation());
+  }
+
+  @Test
+  public void update_onValidationError_throwConstraintViolationException() {
+    Department dep = Department.builder().name("dep1").location("dep location").build();
+    baseDAO.create(dep);
+
+    dep.setLocation(null);
+
+    assertThrows(
+      ConstraintViolationException.class,
+      () -> baseDAO.update(dep)
+    );
   }
 
 }


### PR DESCRIPTION
…when editing a resource

https://redmine.biodiversity.agr.gc.ca/issues/19939

-Added flush call in BaseDao#update to trigger entity validations.