### PR TITLE
19994 add audit service

### DIFF
--- a/dina-base-api/pom.xml
+++ b/dina-base-api/pom.xml
@@ -23,6 +23,7 @@
     <rsql-jpa.version>2.0.2</rsql-jpa.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
+    <javers.version>5.10.4</javers.version>
   </properties>
 
   <dependencies>
@@ -75,6 +76,12 @@
       <groupId>com.github.tennaito</groupId>
       <artifactId>rsql-jpa</artifactId>
       <version>${rsql-jpa.version}</version>
+    </dependency>
+    <!-- JaVers auditing -->
+    <dependency>
+      <groupId>org.javers</groupId>
+      <artifactId>javers-spring-boot-starter-sql</artifactId>
+      <version>${javers.version}</version>
     </dependency>
     <!--Util-->
     <dependency>

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
@@ -58,8 +58,7 @@ public class AuditService {
 
   /**
    * Commit a snapshot for a given object, A dina authenticated user will be set
-   * as the commit author. a dina user bean must be present for a snap shot to be
-   * generated.
+   * as the commit author. If a user is not present the author will be anonymous.
    * 
    * @param obj - domain object state to persist
    */
@@ -73,8 +72,8 @@ public class AuditService {
 
   /**
    * Commit a shallow delete snapshot for a given object, A dina authenticated
-   * user will be set as the commit author. a dina user bean must be present for a
-   * snap shot to be generated.
+   * user will be set as the commit author. If a user is not present the author
+   * will be anonymous.
    * 
    * @param obj - domain object state to persist
    */

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
@@ -1,0 +1,197 @@
+package ca.gc.aafc.dina.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.javers.core.Javers;
+import org.javers.core.metamodel.object.CdoSnapshot;
+import org.javers.repository.jql.QueryBuilder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Service;
+
+import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+@ConditionalOnProperty(value = "dina.auditing.enabled", havingValue = "true")
+public class AuditService {
+
+  private final Javers javers;
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+  private final Optional<DinaAuthenticatedUser> user;
+
+  /**
+   * Returns a list of Audit snapshots filtered by a given instance and author.
+   * Author and instance can be null for un-filtered results.
+   * 
+   * @param instance - instance to filter may be null
+   * @param author   - author to filter may be null
+   * @param limit    - limit of results
+   * @param skip     - amount of results to skip
+   * @return list of Audit snapshots
+   */
+  public List<CdoSnapshot> findAll(AuditInstance instance, String author, int limit, int skip) {
+    return AuditService.findAll(this.javers, instance, author, limit, skip);
+  }
+
+  /**
+   * Get the total resource count by a given Author and Audit Instance. Author and
+   * instance can be null for un-filtered counts.
+   * 
+   * @param author   - author to filter
+   * @param instance - instance to filter
+   * @return the total resource count
+   */
+  public Long getResouceCount(String author, AuditInstance instance) {
+    return AuditService.getResouceCount(this.jdbcTemplate, author, instance);
+  }
+
+  /**
+   * Commit a snapshot for a given object, A dina authenticated user will be set
+   * as the commit author. a dina user bean must be present for a snap shot to be
+   * generated.
+   * 
+   * @param obj - domain object state to persist
+   */
+  public void audit(@NonNull Object obj) {
+    user.ifPresentOrElse(u -> this.javers.commit(u.getUsername(), obj), () -> logNoUser());
+  }
+
+  /**
+   * Commit a shallow delete snapshot for a given object, A dina authenticated
+   * user will be set as the commit author. a dina user bean must be present for a
+   * snap shot to be generated.
+   * 
+   * @param obj - domain object state to persist
+   */
+  public void auditDeleteEvent(@NonNull Object obj) {
+    user.ifPresentOrElse(
+      u -> this.javers.commitShallowDelete(u.getUsername(), obj),
+      () -> logNoUser());
+  }
+
+  /**
+   * Returns a list of Audit snapshots using a given Javers Facade filtered by a
+   * given instance and author. Author and instance can be null for un-filtered
+   * results.
+   * 
+   * @param javers   - Facade to query
+   * @param instance - instance to filter may be null
+   * @param author   - author to filter may be null
+   * @param limit    - limit of results
+   * @param skip     - amount of results to skip
+   * @return list of Audit snapshots
+   */
+  public static List<CdoSnapshot> findAll(Javers javers, AuditInstance instance, String author, int limit, int skip) {
+    QueryBuilder queryBuilder;
+
+    if (instance != null) {
+      queryBuilder = QueryBuilder.byInstanceId(instance.getId(), instance.getType());
+    } else {
+      queryBuilder = QueryBuilder.anyDomainObject();
+    }
+
+    if (StringUtils.isNotBlank(author)) {
+      queryBuilder.byAuthor(author);
+    }
+
+    queryBuilder.limit(limit);
+    queryBuilder.skip(skip);
+
+    return javers.findSnapshots(queryBuilder.build());
+  }
+
+  /**
+   * Get the total resource count by a given Author and/or Audit Instance. Author
+   * and instance can be null for un-filtered counts.
+   * 
+   * @param jdbc     - NamedParameterJdbcTemplate for the query
+   * @param author   - author to filter
+   * @param instance - instance filter to apply
+   * @return the total resource count
+   */
+  public static Long getResouceCount(@NonNull NamedParameterJdbcTemplate jdbc, String author, AuditInstance instance) {
+
+    String id = null;
+    String type = null;
+
+    if (instance != null) {
+      id = instance.getId();
+      type = instance.getType();
+    }
+
+    SqlParameterSource parameters = new MapSqlParameterSource()
+      .addValue("author", author)
+      .addValue("id", id)
+      .addValue("type", type);
+
+    String sql = getResouceCountSql(author, id);
+    return jdbc.queryForObject(sql, parameters, Long.class);
+  }
+
+  /**
+   * Returns the needed SQL String to return a resouce count for a specific author
+   * and id. Author and id can be null for un-filtered counts.
+   * 
+   * @param author - author filter to apply
+   * @param id     - id filter to apply
+   * @return SQL String to return a resouce count
+   */
+  private static String getResouceCountSql(String author, String id) {
+    String baseSql = "select count(*) from jv_snapshot s join jv_commit c on s.commit_fk = c.commit_pk where 1=1 %s %s ;";
+    String sql = String.format(
+      baseSql,
+      StringUtils.isNotBlank(author) ? "and c.author = :author" : "",
+      StringUtils.isNotBlank(id)
+        ? "and global_id_fk = (select global_id_pk from jv_global_id where local_id = :id and type_name = :type)"
+        : "");
+    return sql;
+  }
+
+  private static void logNoUser() {
+    log.warn("No Dina Authenticated user, Auditing has been skipped!");
+  }
+
+  @Builder
+  @Data
+  public static final class AuditInstance {
+
+    @NonNull
+    private final String type;
+    @NonNull
+    private final String id;
+
+    /**
+     * Returns an Optional AuditInstance from a string representation or empty if the
+     * string is blank. Expected string format is {type}/{id}.
+     * 
+     * @param instanceString - string to parse
+     * @throws IllegalArgumentException if the string has an invalid format.
+     * @return Optional AuditInstance or empty for blank strings
+     */
+    public static Optional<AuditInstance> fromString(String instanceString) {
+      if (StringUtils.isBlank(instanceString)) {
+        return Optional.empty();
+      }
+
+      String[] split = instanceString.split("/");
+      if (split.length != 2) {
+        throw new IllegalArgumentException(
+          "Invalid ID must be formatted as {type}/{id}: " + instanceString);
+      }
+      return Optional.of(AuditInstance.builder().type(split[0]).id(split[1]).build());
+    }
+
+  }
+
+}

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/DinaUserConfig.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/DinaUserConfig.java
@@ -1,0 +1,18 @@
+package ca.gc.aafc.dina;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
+
+/** When you need an Authenticated user bean */
+@Configuration
+public class DinaUserConfig {
+
+  public static final String AUTH_USER_NAME = "username";
+
+  @Bean
+  public DinaAuthenticatedUser user() {
+    return DinaAuthenticatedUser.builder().username(DinaUserConfig.AUTH_USER_NAME).build();
+  }
+}

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/dto/EmployeeDto.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/dto/EmployeeDto.java
@@ -1,5 +1,10 @@
 package ca.gc.aafc.dina.dto;
 
+import org.javers.core.metamodel.annotation.DiffIgnore;
+import org.javers.core.metamodel.annotation.Id;
+import org.javers.core.metamodel.annotation.PropertyName;
+import org.javers.core.metamodel.annotation.TypeName;
+
 import ca.gc.aafc.dina.entity.Employee;
 import ca.gc.aafc.dina.mapper.DerivedDtoField;
 import io.crnk.core.resource.annotations.JsonApiId;
@@ -11,14 +16,19 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@JsonApiResource(type = "employee")
+@JsonApiResource(type = EmployeeDto.TYPENAME)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @RelatedEntity(Employee.class)
+@TypeName(EmployeeDto.TYPENAME)
 public class EmployeeDto {
 
+  public static final String TYPENAME = "employee";
+
   @JsonApiId
+  @Id
+  @PropertyName("id")
   private Integer id;
 
   private String name;
@@ -32,6 +42,7 @@ public class EmployeeDto {
   private String customField;
 
   @JsonApiRelation
+  @DiffIgnore
   private DepartmentDto department;
 
 }

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/service/AuditServiceIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/service/AuditServiceIT.java
@@ -1,0 +1,163 @@
+package ca.gc.aafc.dina.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.javers.core.Javers;
+import org.javers.core.metamodel.object.CdoSnapshot;
+import org.javers.core.metamodel.object.SnapshotType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import ca.gc.aafc.dina.DinaUserConfig;
+import ca.gc.aafc.dina.TestConfiguration;
+import ca.gc.aafc.dina.dto.EmployeeDto;
+import ca.gc.aafc.dina.service.AuditService.AuditInstance;
+
+@SpringBootTest(classes = TestConfiguration.class, properties = "dina.auditing.enabled = true")
+public class AuditServiceIT {
+
+  @Inject
+  private Javers javers;
+
+  @Inject
+  private AuditService serviceUnderTest;
+
+  @Inject
+  private NamedParameterJdbcTemplate jdbcTemplate;
+
+  private static final String AUTHOR = "dina_user";
+  private static final String TYPE = EmployeeDto.TYPENAME;
+  private static final Integer INSTANCE_ID = RandomUtils.nextInt();
+
+  /**
+   * Persists 6 snap shots in total for each test. Total expected commits for
+   * Author = 4, Instance = 2, No Filter = 6
+   */
+  @BeforeEach
+  public void beforeEachTest() {
+    cleanSnapShotRepo();
+
+    // Has Author 2 Commits
+    EmployeeDto hasAuthor = createDto();
+    javers.commit(AUTHOR, hasAuthor);
+    hasAuthor.setName("update");
+    javers.commit(AUTHOR, hasAuthor);
+
+    // Anonymous Author 2 Commits
+    EmployeeDto noAuthor = createDto();
+    javers.commit("Anonymous", noAuthor);
+    noAuthor.setName("update");
+    javers.commit("Anonymous", noAuthor);
+
+    // Has Author With specific instance id 2 commits
+    EmployeeDto withInstanceID = createDto();
+    withInstanceID.setId(INSTANCE_ID);
+    javers.commit(AUTHOR, withInstanceID);
+    withInstanceID.setName("update");
+    javers.commit(AUTHOR, withInstanceID);
+  }
+
+  @Test
+  public void findAll_whenNoFilter_AllSnapShotsReturned() {
+    List<CdoSnapshot> results = serviceUnderTest.findAll(null, null, 10, 0);
+    assertEquals(6, results.size());
+  }
+
+  @Test
+  public void findAll_whenFilteredByInstance_snapshotsFiltered() {
+    AuditInstance instance = AuditInstance.builder()
+      .type(TYPE)
+      .id(Integer.toString(INSTANCE_ID))
+      .build();
+    List<CdoSnapshot> results = serviceUnderTest.findAll(instance, null, 10, 0);
+    assertEquals(2, results.size());
+    results.forEach(shot -> 
+      assertEquals(
+        String.join("/", TYPE, Integer.toString(INSTANCE_ID)),
+        shot.getGlobalId().toString()));
+  }
+
+  @Test
+  public void findAll_whenFilteredByAuthor_snapshotsFiltered() {
+    List<CdoSnapshot> results = serviceUnderTest.findAll(null, AUTHOR, 10, 0);
+    assertEquals(4, results.size());
+    results.forEach(shot -> assertEquals(AUTHOR, shot.getCommitMetadata().getAuthor()));
+  }
+
+  @Test
+  public void findAll_WithLimit_LimitsResults() {
+    List<CdoSnapshot> results = serviceUnderTest.findAll(null, null, 1, 0);
+    assertEquals(1, results.size());
+  }
+
+  @Test
+  public void findAll_WithOffset_ResultsOffset() {
+    List<CdoSnapshot> results = serviceUnderTest.findAll(null, null, 10, 5);
+    assertEquals(1, results.size());
+  }
+
+  @Test
+  public void getResouceCount_NoFilter_ReturnsAllCount() {
+    Long expected = serviceUnderTest.getResouceCount(null, null);
+    assertEquals(Long.valueOf(6), expected);
+  }
+
+  @Test
+  public void getResouceCount_AuthorFilter_ReturnsFilteredCount() {
+    Long expected = serviceUnderTest.getResouceCount(AUTHOR, null);
+    assertEquals(Long.valueOf(4), expected);
+  }
+
+  @Test
+  public void getResouceCount_InstanceFilter_ReturnsFilteredCount() {
+    AuditInstance instance = AuditInstance.builder()
+      .type(TYPE)
+      .id(Integer.toString(INSTANCE_ID))
+      .build();
+    Long expected = serviceUnderTest.getResouceCount(null, instance);
+    assertEquals(Long.valueOf(2), expected);
+  }
+
+  @Test
+  public void audit_SnapShotPersistedWithAuthor() {
+    EmployeeDto dto = createDto();
+    serviceUnderTest.audit(dto);
+
+    CdoSnapshot result = javers.getLatestSnapshot(dto.getId(), EmployeeDto.class).orElse(null);
+    assertNotNull(result);
+    assertEquals(DinaUserConfig.AUTH_USER_NAME, result.getCommitMetadata().getAuthor());
+  }
+
+  @Test
+  public void auditDeleteEvent_TerminalSnapShotPersistedWithAuthor() {
+    EmployeeDto dto = createDto();
+    serviceUnderTest.audit(dto);
+    serviceUnderTest.auditDeleteEvent(dto);
+
+    CdoSnapshot result = javers.getLatestSnapshot(dto.getId(), EmployeeDto.class).orElse(null);
+    assertNotNull(result);
+    assertEquals(SnapshotType.TERMINAL, result.getType());
+    assertEquals(DinaUserConfig.AUTH_USER_NAME, result.getCommitMetadata().getAuthor());
+  }
+
+  private static EmployeeDto createDto() {
+    EmployeeDto dto = new EmployeeDto();
+    dto.setId(RandomUtils.nextInt());
+    return dto;
+  }
+
+  private void cleanSnapShotRepo() {
+    jdbcTemplate.update("DELETE FROM jv_snapshot where commit_fk IS NOT null", Collections.emptyMap());
+    jdbcTemplate.update("DELETE FROM jv_commit where commit_pk IS NOT null", Collections.emptyMap());
+  }
+
+}


### PR DESCRIPTION
- Introducing AuditService.java

- Allows javers snapshot repository access. Bean is accessible through enviroment property: 
`@ConditionalOnProperty(value = "dina.auditing.enabled", havingValue = "true")`

- Test should prove the interface is behaving as expected.