### PR TITLE
19995 add audit repo

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/dto/AuditSnapshotDto.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/dto/AuditSnapshotDto.java
@@ -1,0 +1,47 @@
+package ca.gc.aafc.dina.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.crnk.core.resource.annotations.JsonApiId;
+import io.crnk.core.resource.annotations.JsonApiResource;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@JsonApiResource(type = "audit-snapshot")
+@Data
+@SuppressFBWarnings({ "EI_EXPOSE_REP", "EI_EXPOSE_REP2" })
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuditSnapshotDto {
+
+  @JsonApiId
+  private String id;
+
+  /**
+   * The audited record's type and ID.
+   * e.g. metadata/16b3a97c-5485-4920-891d-e0709f3b22d4
+   */
+  private String instanceId;
+
+  /** Snapshot state. */
+  private Map<String, Object> state;
+
+  private List<String> changedProperties;
+
+  /** INITIAL / UPDATE / TERMINAL */
+  private String snapshotType;
+
+  private Long version;
+
+  /** Who made the change. */
+  private String author;
+
+  private OffsetDateTime commitDateTime;
+
+}

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/auditlog/AuditSnapshotRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/auditlog/AuditSnapshotRepository.java
@@ -1,0 +1,98 @@
+package ca.gc.aafc.dina.repository.auditlog;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.javers.core.metamodel.object.CdoSnapshot;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Repository;
+
+import ca.gc.aafc.dina.dto.AuditSnapshotDto;
+import ca.gc.aafc.dina.repository.NoLinkInformation;
+import ca.gc.aafc.dina.service.AuditService;
+import ca.gc.aafc.dina.service.AuditService.AuditInstance;
+import io.crnk.core.exception.MethodNotAllowedException;
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.ReadOnlyResourceRepositoryBase;
+import io.crnk.core.resource.list.DefaultResourceList;
+import io.crnk.core.resource.list.ResourceList;
+import io.crnk.core.resource.meta.DefaultPagedMetaInformation;
+
+@Repository
+@ConditionalOnProperty(value = "dina.auditing.enabled", havingValue = "true")
+public class AuditSnapshotRepository extends ReadOnlyResourceRepositoryBase<AuditSnapshotDto, Long> {
+
+  private final AuditService service;
+
+  public AuditSnapshotRepository(AuditService service) {
+    super(AuditSnapshotDto.class);
+    this.service = service;
+  }
+
+  @Override
+  public ResourceList<AuditSnapshotDto> findAll(QuerySpec qs) {
+    int limit = Optional.ofNullable(qs.getLimit()).orElse(100L).intValue();
+    int skip = Optional.ofNullable(qs.getOffset()).orElse(0L).intValue();
+
+    Map<String, String> filters = getFilterMap(qs);
+    String authorFilter = filters.get("author");
+    String instanceFilter = filters.get("instanceId");
+
+    AuditInstance instance = AuditInstance.fromString(instanceFilter).orElse(null);
+
+    List<AuditSnapshotDto> dtos = service.findAll(instance, authorFilter, limit, skip)
+      .stream().map(AuditSnapshotRepository::toDto).collect(Collectors.toList());
+
+    Long count = service.getResouceCount(authorFilter, instance);
+    DefaultPagedMetaInformation meta = new DefaultPagedMetaInformation();
+    meta.setTotalResourceCount(count);
+
+    return new DefaultResourceList<>(dtos, meta, new NoLinkInformation());
+  }
+
+  @Override
+  public AuditSnapshotDto findOne(Long id, QuerySpec querySpec) {
+    // Disable findOne.
+    throw new MethodNotAllowedException("method not allowed");
+  }
+
+  /** Converts Javers snapshot to our DTO format. */
+  private static AuditSnapshotDto toDto(CdoSnapshot original) {
+    // Get the snapshot state as a map:
+    Map<String, Object> state = new HashMap<>();
+    original.getState().forEachProperty((key, val) -> state.put(key, val));
+
+    // Get the commit date as OffsetDateTime:
+    OffsetDateTime commitDateTime = original.getCommitMetadata().getCommitDate().atOffset(OffsetDateTime.now().getOffset());
+
+    return AuditSnapshotDto.builder()
+        .id(original.getGlobalId().value() + "/" + commitDateTime)   
+        .instanceId(original.getGlobalId().value())
+        .state(state)
+        .changedProperties(original.getChanged())
+        .snapshotType(original.getType().toString())
+        .version(original.getVersion())
+        .author(original.getCommitMetadata().getAuthor())
+        .commitDateTime(commitDateTime)
+        .build();
+  }
+
+  /**
+   * Converts Crnk's filters into a String/String Map.
+   */
+  private static Map<String, String> getFilterMap(QuerySpec qs) {
+    Map<String, String> map = new HashMap<>();
+    qs.getFilters().forEach(
+      it -> map.put(
+        it.getPath().toString(),
+        it.getValue().toString()
+      )
+    );
+    return map;
+  }
+
+}

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/auditlog/AuditSnapshotRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/auditlog/AuditSnapshotRepository.java
@@ -26,6 +26,11 @@ import io.crnk.core.resource.meta.DefaultPagedMetaInformation;
 @ConditionalOnProperty(value = "dina.auditing.enabled", havingValue = "true")
 public class AuditSnapshotRepository extends ReadOnlyResourceRepositoryBase<AuditSnapshotDto, Long> {
 
+  private static final long DEFAULT_SKIP = 0L;
+  private static final long DEFAULT_LIMIT = 100L;
+  private static final String INSTANCE_FILTER_VALUE = "instanceId";
+  private static final String AUTHOR_FILTER_VALUE = "author";
+
   private final AuditService service;
 
   public AuditSnapshotRepository(AuditService service) {
@@ -35,12 +40,12 @@ public class AuditSnapshotRepository extends ReadOnlyResourceRepositoryBase<Audi
 
   @Override
   public ResourceList<AuditSnapshotDto> findAll(QuerySpec qs) {
-    int limit = Optional.ofNullable(qs.getLimit()).orElse(100L).intValue();
-    int skip = Optional.ofNullable(qs.getOffset()).orElse(0L).intValue();
+    int limit = Optional.ofNullable(qs.getLimit()).orElse(DEFAULT_LIMIT).intValue();
+    int skip = Optional.ofNullable(qs.getOffset()).orElse(DEFAULT_SKIP).intValue();
 
     Map<String, String> filters = getFilterMap(qs);
-    String authorFilter = filters.get("author");
-    String instanceFilter = filters.get("instanceId");
+    String authorFilter = filters.get(AUTHOR_FILTER_VALUE);
+    String instanceFilter = filters.get(INSTANCE_FILTER_VALUE);
 
     AuditInstance instance = AuditInstance.fromString(instanceFilter).orElse(null);
 

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/repository/AuditSnapshotRepositoryIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/repository/AuditSnapshotRepositoryIT.java
@@ -1,0 +1,114 @@
+package ca.gc.aafc.dina.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.javers.core.Javers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import ca.gc.aafc.dina.TestConfiguration;
+import ca.gc.aafc.dina.dto.AuditSnapshotDto;
+import ca.gc.aafc.dina.dto.EmployeeDto;
+import ca.gc.aafc.dina.repository.auditlog.AuditSnapshotRepository;
+import io.crnk.core.queryspec.FilterOperator;
+import io.crnk.core.queryspec.FilterSpec;
+import io.crnk.core.queryspec.PathSpec;
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.resource.list.ResourceList;
+import io.crnk.core.resource.meta.PagedMetaInformation;
+
+@SpringBootTest(classes = TestConfiguration.class, properties = "dina.auditing.enabled = true")
+public class AuditSnapshotRepositoryIT {
+
+  @Inject
+  private AuditSnapshotRepository snapshotRepo;
+
+  @Inject
+  private Javers javers;
+
+  @Inject
+  private NamedParameterJdbcTemplate jdbcTemplate;
+
+  private static final String AUTHOR = "dina_user";
+  private static final String TYPE = EmployeeDto.TYPENAME;
+  private static final Integer INSTANCE_ID = RandomUtils.nextInt();
+  private static final String ANONYMOUS = "Anonymous";
+
+  @BeforeEach
+  public void setup() {
+    cleanSnapShotRepo();
+    // Has Author 2 Commits
+    EmployeeDto hasAuthor = createDto();
+    javers.commit(AUTHOR, hasAuthor);
+    hasAuthor.setName("update");
+    javers.commit(AUTHOR, hasAuthor);
+
+    // Anonymous Author 2 Commits
+    EmployeeDto noAuthor = createDto();
+    javers.commit(ANONYMOUS, noAuthor);
+    noAuthor.setName("update");
+    javers.commit(ANONYMOUS, noAuthor);
+
+    // Has Author With specific instance id 2 commits
+    EmployeeDto withInstanceID = createDto();
+    withInstanceID.setId(INSTANCE_ID);
+    javers.commit(AUTHOR, withInstanceID);
+    withInstanceID.setName("update");
+    javers.commit(AUTHOR, withInstanceID);
+  }
+
+  @Test
+  public void findAll_whenNoFilter_allSnapshotsReturned() {
+    QuerySpec qs = new QuerySpec(AuditSnapshotDto.class);
+    ResourceList<AuditSnapshotDto> snapshots = snapshotRepo.findAll(qs);
+    assertEquals(6, snapshots.size());
+    assertEquals(6, ((PagedMetaInformation) snapshots.getMeta()).getTotalResourceCount());
+  }
+
+  @Test
+  public void findAll_whenFilteredByInstance_snapshotsFiltered() {
+    QuerySpec qs = new QuerySpec(AuditSnapshotDto.class);
+    qs.addFilter(filter("instanceId", TYPE + "/" + INSTANCE_ID));
+    ResourceList<AuditSnapshotDto> snapshots = snapshotRepo.findAll(qs);
+    assertEquals(2, snapshots.size());
+    assertEquals(2, ((PagedMetaInformation) snapshots.getMeta()).getTotalResourceCount());
+  }
+
+  @Test
+  public void findAll_whenFilteredByAuthor_snapshotsFiltered() {
+    QuerySpec qs1 = new QuerySpec(AuditSnapshotDto.class);
+    qs1.addFilter(filter("author", AUTHOR));
+    ResourceList<AuditSnapshotDto> snapshots1 = snapshotRepo.findAll(qs1);
+    assertEquals(4, snapshots1.size());
+    assertEquals(4, ((PagedMetaInformation) snapshots1.getMeta()).getTotalResourceCount());
+
+    QuerySpec qs2 = new QuerySpec(AuditSnapshotDto.class);
+    qs2.addFilter(filter("author", "other-user"));
+    ResourceList<AuditSnapshotDto> snapshots2 = snapshotRepo.findAll(qs2);
+    assertEquals(0, snapshots2.size());
+    assertEquals(0, ((PagedMetaInformation) snapshots2.getMeta()).getTotalResourceCount());
+  }
+
+  private FilterSpec filter(String attribute, String value) {
+    return new FilterSpec(PathSpec.of(attribute), FilterOperator.EQ, value);
+  }
+
+  private static EmployeeDto createDto() {
+    EmployeeDto dto = new EmployeeDto();
+    dto.setId(RandomUtils.nextInt());
+    return dto;
+  }
+
+  private void cleanSnapShotRepo() {
+    jdbcTemplate.update("DELETE FROM jv_snapshot where commit_fk IS NOT null", Collections.emptyMap());
+    jdbcTemplate.update("DELETE FROM jv_commit where commit_pk IS NOT null", Collections.emptyMap());
+  }
+
+}


### PR DESCRIPTION
Introduces the Audit Snapshot Repository. 

Provides an endpoint to request audit snap shots.

Activated with the property `dina.auditing.enabled=true`