### PR TITLE
20138 enhance dina service

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DinaService.java
@@ -78,16 +78,16 @@ public class DinaService<E extends DinaEntity> {
    *                      - maximun number of results to return
    * @return list of entities
    */
-  public List<E> findAll(
-    @NonNull Class<E> entityClass,
-    @NonNull BiFunction<CriteriaBuilder, Root<E>, Predicate[]> where,
-    BiFunction<CriteriaBuilder, Root<E>, List<Order>> orderBy,
+  public <T> List<T> findAll(
+    @NonNull Class<T> entityClass,
+    @NonNull BiFunction<CriteriaBuilder, Root<T>, Predicate[]> where,
+    BiFunction<CriteriaBuilder, Root<T>, List<Order>> orderBy,
     int startIndex,
     int maxResult
   ) {
     CriteriaBuilder criteriaBuilder = baseDAO.getCriteriaBuilder();
-    CriteriaQuery<E> criteria = criteriaBuilder.createQuery(entityClass);
-    Root<E> root = criteria.from(entityClass);
+    CriteriaQuery<T> criteria = criteriaBuilder.createQuery(entityClass);
+    Root<T> root = criteria.from(entityClass);
 
     criteria.where(where.apply(criteriaBuilder, root)).select(root);
     if (orderBy != null) {
@@ -105,9 +105,9 @@ public class DinaService<E extends DinaEntity> {
    *                            - function to return the predicates cannot be null
    * @return resource count
    */
-  public Long getResourceCount(
-    @NonNull Class<E> entityClass,
-    @NonNull BiFunction<CriteriaBuilder, Root<E>, Predicate[]> predicateSupplier
+  public <T> Long getResourceCount(
+    @NonNull Class<T> entityClass,
+    @NonNull BiFunction<CriteriaBuilder, Root<T>, Predicate[]> predicateSupplier
   ) {
     return baseDAO.getResourceCount(entityClass, predicateSupplier);
   }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DinaService.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
  */
 @Component
 @RequiredArgsConstructor(onConstructor_ = @Inject)
-public abstract class DinaService<E extends DinaEntity> {
+public class DinaService<E extends DinaEntity> {
 
   @NonNull
   private final BaseDAO baseDAO;
@@ -137,30 +137,30 @@ public abstract class DinaService<E extends DinaEntity> {
   }
 
   /**
-   * Run before the {@link DinaService#create()} method.
+   * Run before the {@link DinaService#create(DinaEntity)} method.
    *
-   * @param entity entity being created by {@link DinaService#create()}
+   * @param entity entity being created by {@link DinaService#create(DinaEntity)}
    */
   protected void preCreate(E entity) {
     // Defaults to do nothing
-  };
+  }
 
   /**
-   * Run before the {@link DinaService#update()} method.
+   * Run before the {@link DinaService#update(DinaEntity)} method.
    *
-   * @param entity entity being updated by {@link DinaService#update()}
+   * @param entity entity being updated by {@link DinaService#update(DinaEntity)}
    */
   protected void preUpdate(E entity) {
     // Defaults to do nothing
-  };
+  }
 
   /**
-   * Run before the {@link DinaService#delete()} method.
+   * Run before the {@link DinaService#delete(DinaEntity)} method.
    *
-   * @param entity entity being deleted by {@link DinaService#delete()}
+   * @param entity entity being deleted by {@link DinaService#delete(DinaEntity)}
    */
   protected void preDelete(E entity) {
     // Defaults to do nothing
-  };
+  }
 
 }


### PR DESCRIPTION
Dina service is no longer abstract. You can create and use the class without implementing it.

find all and get resource count are generically separate from Dina service para type.

DinaService use of generics still make sense for create and pre create type operations to use the same type.
