### PR TITLE
20252 dina repo operations it

### DIFF
--- a/dina-base-api/pom.xml
+++ b/dina-base-api/pom.xml
@@ -64,6 +64,11 @@
       <artifactId>crnk-operations</artifactId>
       <version>${crnk.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.crnk</groupId>
+      <artifactId>crnk-client</artifactId>
+      <version>${crnk.version}</version>
+    </dependency>
     <!-- RSQL -->
     <dependency>
       <groupId>com.github.tennaito</groupId>

--- a/dina-base-api/pom.xml
+++ b/dina-base-api/pom.xml
@@ -68,6 +68,7 @@
       <groupId>io.crnk</groupId>
       <artifactId>crnk-client</artifactId>
       <version>${crnk.version}</version>
+      <scope>test</scope>
     </dependency>
     <!-- RSQL -->
     <dependency>

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoBulkOperationIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoBulkOperationIT.java
@@ -133,7 +133,34 @@ public class DinaRepoBulkOperationIT extends BaseRestAssuredTest {
     Assertions.assertEquals(0, projectRepo.findAll(new QuerySpec(ProjectDTO.class)).size());
   }
 
+  @Test
+  void bulkUpdate() {
+    ProjectDTO project1 = createProjectDTO();
+    ProjectDTO project2 = createProjectDTO();
+
+    OperationsCall call = operationsClient.createCall();
+    call.add(HttpMethod.POST, project1);
+    call.add(HttpMethod.POST, project2);
+    call.execute();
+
+    project1.setName(RandomStringUtils.randomAlphabetic(5));
+    project2.setName(RandomStringUtils.randomAlphabetic(5));
+
+    call = operationsClient.createCall();
+    call.add(HttpMethod.PATCH, project1);
+    call.add(HttpMethod.PATCH, project2);
+    call.execute();
+
+    assertProject(
+      project1,
+      projectRepo.findOne(project1.getUuid(), new QuerySpec(ProjectDTO.class)));
+    assertProject(
+      project2,
+      projectRepo.findOne(project2.getUuid(), new QuerySpec(ProjectDTO.class)));
+  }
+
   private void assertProject(ProjectDTO expected, ProjectDTO result) {
+    Assertions.assertEquals(expected.getUuid(), result.getUuid());
     Assertions.assertEquals(expected.getName(), result.getName());
   }
 

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoBulkOperationIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoBulkOperationIT.java
@@ -79,6 +79,7 @@ public class DinaRepoBulkOperationIT extends BaseRestAssuredTest {
     //Clean up test data
     projectRepo.findAll(createProjectQuerySpec())
       .forEach(projectDTO -> projectRepo.delete(projectDTO.getUuid()));
+    taskRepo.findAll(new QuerySpec(TaskDTO.class)).forEach(task -> taskRepo.delete(task.getUuid()));
   }
 
   @Test
@@ -123,7 +124,7 @@ public class DinaRepoBulkOperationIT extends BaseRestAssuredTest {
   }
 
   @Test
-  void bulkUpdate() {
+  void bulkUpdate_ResourcesUpdatedWithRelationship() {
     ProjectDTO project1 = createProjectDTO();
     ProjectDTO project2 = createProjectDTO();
 
@@ -133,9 +134,13 @@ public class DinaRepoBulkOperationIT extends BaseRestAssuredTest {
     call.execute();
 
     project1.setName(RandomStringUtils.randomAlphabetic(5));
+    project1.setTask(createTaskDTO());
     project2.setName(RandomStringUtils.randomAlphabetic(5));
+    project2.setTask(createTaskDTO());
 
     call = operationsClient.createCall();
+    call.add(HttpMethod.POST, project1.getTask());
+    call.add(HttpMethod.POST, project2.getTask());
     call.add(HttpMethod.PATCH, project1);
     call.add(HttpMethod.PATCH, project2);
     call.execute();
@@ -151,6 +156,8 @@ public class DinaRepoBulkOperationIT extends BaseRestAssuredTest {
       Assertions.assertNotNull(result.getTask());
       Assertions.assertEquals(expected.getTask().getUuid(), result.getTask().getUuid());
       Assertions.assertEquals(expected.getTask().getPowerLevel(), result.getTask().getPowerLevel());
+    } else {
+      Assertions.assertNull(result.getTask());
     }
   }
 

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoBulkOperationIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoBulkOperationIT.java
@@ -113,10 +113,6 @@ public class DinaRepoBulkOperationIT extends BaseRestAssuredTest {
       projectRepo.findOne(project2.getUuid(), new QuerySpec(ProjectDTO.class)));
   }
 
-  private void assertProject(ProjectDTO expected, ProjectDTO result) {
-    Assertions.assertEquals(expected.getName(), result.getName());
-  }
-
   @Test
   void bulkDelete() {
     ProjectDTO project1 = createProjectDTO();
@@ -135,6 +131,10 @@ public class DinaRepoBulkOperationIT extends BaseRestAssuredTest {
     call.execute();
 
     Assertions.assertEquals(0, projectRepo.findAll(new QuerySpec(ProjectDTO.class)).size());
+  }
+
+  private void assertProject(ProjectDTO expected, ProjectDTO result) {
+    Assertions.assertEquals(expected.getName(), result.getName());
   }
 
   private static ProjectDTO createProjectDTO() {

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoBulkOperationIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoBulkOperationIT.java
@@ -1,0 +1,149 @@
+package ca.gc.aafc.dina.jsonapi;
+
+import ca.gc.aafc.dina.dto.RelatedEntity;
+import ca.gc.aafc.dina.entity.DinaEntity;
+import ca.gc.aafc.dina.filter.DinaFilterResolver;
+import ca.gc.aafc.dina.jpa.BaseDAO;
+import ca.gc.aafc.dina.mapper.DinaMapper;
+import ca.gc.aafc.dina.repository.DinaRepository;
+import ca.gc.aafc.dina.service.DinaService;
+import ca.gc.aafc.dina.testsupport.BaseRestAssuredTest;
+import ca.gc.aafc.dina.testsupport.jsonapi.JsonAPIOperationBuilder;
+import ca.gc.aafc.dina.testsupport.jsonapi.JsonAPITestHelper;
+import io.crnk.core.engine.http.HttpMethod;
+import io.crnk.core.resource.annotations.JsonApiId;
+import io.crnk.core.resource.annotations.JsonApiResource;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.ValidatableResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.hibernate.annotations.NaturalId;
+import org.javers.core.metamodel.annotation.PropertyName;
+import org.javers.core.metamodel.annotation.TypeName;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@SpringBootTest(
+  properties = {"dev-user.enabled: true", "keycloak.enabled: false"},
+  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+public class DinaRepoBulkOperationIT extends BaseRestAssuredTest {
+
+  public DinaRepoBulkOperationIT() {
+    super("");
+  }
+
+  @TestConfiguration
+  @EntityScan(basePackageClasses = DinaRepoBulkOperationIT.class)
+  static class DinaRepoBulkOperationITConfig {
+    @Bean
+    public DinaRepository<ProjectDTO, Project> projectRepo(
+      BaseDAO baseDAO,
+      DinaFilterResolver filterResolver
+    ) {
+      return new DinaRepository<>(
+        new DinaService<>(baseDAO),
+        Optional.empty(),
+        Optional.empty(),
+        new DinaMapper<>(ProjectDTO.class),
+        ProjectDTO.class,
+        Project.class,
+        filterResolver
+      );
+    }
+  }
+
+  @Test
+  void bulkPost() {
+    ProjectDTO project1 = createProjectDTO();
+    ProjectDTO project2 = createProjectDTO();
+    Map<String, Object> project1Map = projectToMap(project1, UUID.randomUUID().toString());
+    Map<String, Object> project2Map = projectToMap(project2, UUID.randomUUID().toString());
+
+    List<Map<String, Object>> operationMap = JsonAPIOperationBuilder.newBuilder()
+      .addOperation(HttpMethod.POST, ProjectDTO.RESOURCE_TYPE, project1Map)
+      .addOperation(HttpMethod.POST, ProjectDTO.RESOURCE_TYPE, project2Map)
+      .buildOperation();
+
+    ValidatableResponse operationResponse = sendOperation(operationMap);
+
+    Integer returnCodePerson1 = operationResponse.extract().body().jsonPath().getInt("[0].status");
+    String project1ID = operationResponse.extract().body().jsonPath().getString("[0].data.id");
+
+    Integer returnCodePerson2 = operationResponse.extract().body().jsonPath().getInt("[1].status");
+    String project2ID = operationResponse.extract().body().jsonPath().getString("[1].data.id");
+
+    Assertions.assertEquals(201, returnCodePerson1);
+    Assertions.assertEquals(201, returnCodePerson2);
+    assertPersonFromResponse(sendGet(ProjectDTO.RESOURCE_TYPE, project1ID, 200), project1);
+    assertPersonFromResponse(sendGet(ProjectDTO.RESOURCE_TYPE, project2ID, 200), project2);
+  }
+
+  private static void assertPersonFromResponse(ValidatableResponse response, ProjectDTO dto) {
+    JsonPath jsonPath = response.extract().body().jsonPath();
+    Assertions.assertEquals(dto.name, jsonPath.getString("data.attributes.name"));
+  }
+
+  private static Map<String, Object> projectToMap(ProjectDTO project, String id) {
+    return JsonAPITestHelper.toJsonAPIMap(
+      ProjectDTO.RESOURCE_TYPE,
+      JsonAPITestHelper.toAttributeMap(project),
+      null,
+      id);
+  }
+
+  private static ProjectDTO createProjectDTO() {
+    return ProjectDTO.builder()
+      .name(RandomStringUtils.randomAlphabetic(5))
+      .build();
+  }
+
+  @Data
+  @Entity
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static final class Project implements DinaEntity {
+    @Id
+    @GeneratedValue
+    private Integer id;
+    @NaturalId
+    private UUID uuid;
+    private String name;
+    private OffsetDateTime createdOn;
+    private String createdBy;
+  }
+
+  @Data
+  @JsonApiResource(type = ProjectDTO.RESOURCE_TYPE)
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @RelatedEntity(Project.class)
+  @TypeName(ProjectDTO.RESOURCE_TYPE)
+  public static final class ProjectDTO {
+    public static final String RESOURCE_TYPE = "Project";
+    @JsonApiId
+    @org.javers.core.metamodel.annotation.Id
+    @PropertyName("id")
+    private UUID uuid;
+    private String name;
+  }
+
+}

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoBulkOperationIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoBulkOperationIT.java
@@ -98,12 +98,8 @@ public class DinaRepoBulkOperationIT extends BaseRestAssuredTest {
     Assertions.assertEquals(2, projectRepo.findAll(createProjectQuerySpec()).size());
     Assertions.assertEquals(2, taskRepo.findAll(new QuerySpec(TaskDTO.class)).size());
 
-    assertProject(
-      project1,
-      projectRepo.findOne(project1.getUuid(), createProjectQuerySpec()));
-    assertProject(
-      project2,
-      projectRepo.findOne(project2.getUuid(), createProjectQuerySpec()));
+    assertProject(project1, projectRepo.findOne(project1.getUuid(), createProjectQuerySpec()));
+    assertProject(project2, projectRepo.findOne(project2.getUuid(), createProjectQuerySpec()));
   }
 
   @Test

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoBulkOperationIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoBulkOperationIT.java
@@ -68,7 +68,7 @@ public class DinaRepoBulkOperationIT extends BaseRestAssuredTest {
 
   @BeforeEach
   void setUp() {
-    String url = "http://localhost:8080/" + super.basePath;
+    String url = "http://localhost:" + super.testPort + "/" + super.basePath;
     CrnkClient client = new CrnkClient(url);
     operationsClient = new OperationsClient(client);
     client.setHttpAdapter(new InMemoryHttpAdapter(boot, url));


### PR DESCRIPTION
Adds a test suite to test that the dina repo can support the basic Bulk operations module provided by crnk.

The main edge cases for the test are as follows:
- Bulk Post of a resource with basic attributes and a relationship
- Bulk Update of a resource's basic attributes and relationship
- Bulk deleting a resource 