### PR TITLE
20342 partial update dina repo wipes relationship

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -338,6 +338,13 @@ public class DinaRepository<D, E extends DinaEntity>
         returnPersistedObject(findIdFieldName(resourceField.getElementType()), relation));
   }
 
+  /**
+   * Maps the given relations from the given entity to a given dto in a shallow form (Id only).
+   *
+   * @param entity         - source of the mapping
+   * @param dto            - target of the mapping
+   * @param relationsToMap - relations to map
+   */
   private void mapShallowRelations(E entity, D dto, List<ResourceField> relationsToMap) {
     mapRelations(entity, dto, relationsToMap,
       (resourceField, relation) -> {
@@ -346,6 +353,14 @@ public class DinaRepository<D, E extends DinaEntity>
       });
   }
 
+  /**
+   * Maps the given relations from a given source to a given target with a given mapping function.
+   *
+   * @param source    - source of the mapping
+   * @param target    - target of the mapping
+   * @param relations - relations to map
+   * @param mapper    - mapping function to apply
+   */
   private void mapRelations(
     Object source,
     Object target,
@@ -430,6 +445,14 @@ public class DinaRepository<D, E extends DinaEntity>
     return clazz.getAnnotation(RelatedEntity.class);
   }
 
+  /**
+   * Maps the given id field name from a given entity to a new instance of a given type.
+   *
+   * @param idFieldName - name of the id field for the mapping
+   * @param type        - type of new instance to return with the mapping
+   * @param entity      - entity with the id to map
+   * @return - a new instance of a given type with a id value mapped from a given entity.
+   */
   @SneakyThrows
   private static Object createShallowDTO(String idFieldName, Class<?> type, Object entity) {
     Object shallowDTO = type.getConstructor().newInstance();
@@ -440,12 +463,24 @@ public class DinaRepository<D, E extends DinaEntity>
     return shallowDTO;
   }
 
+  /**
+   * Returns a list of resource fields for a given class.
+   *
+   * @param clazz - class of relations to find
+   * @return - list of resource fields
+   */
   private List<ResourceField> findRelations(Class<?> clazz) {
     return this.resourceRegistry.findEntry(clazz).getResourceInformation().getRelationshipFields();
   }
 
-  private String findIdFieldName(Class<?> elementType) {
-    return this.resourceRegistry.findEntry(elementType)
+  /**
+   * Returns the id field name for a given class.
+   *
+   * @param clazz - class to find the id field name for
+   * @return - id field name for a given class.
+   */
+  private String findIdFieldName(Class<?> clazz) {
+    return this.resourceRegistry.findEntry(clazz)
       .getResourceInformation()
       .getIdField()
       .getUnderlyingName();

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -130,13 +130,13 @@ public class DinaRepository<D, E extends DinaEntity>
       .findEntry(resourceClass)
       .getResourceInformation();
 
-    List<ResourceField> notIncludedRelations = resourceInformation.getRelationshipFields()
+    List<ResourceField> relationsToMap = resourceInformation.getRelationshipFields()
       .stream()
       .filter(resourceField -> excluded.stream()
         .noneMatch(resourceField.getUnderlyingName()::equalsIgnoreCase))
       .collect(Collectors.toList());
 
-    for (ResourceField relation : notIncludedRelations) {
+    for (ResourceField relation : relationsToMap) {
       String fieldName = relation.getUnderlyingName();
       String relationIdFieldName = resourceInformation.getIdField().getUnderlyingName();
       Class<?> elementType = relation.getElementType();

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -142,7 +142,7 @@ public class DinaRepository<D, E extends DinaEntity>
       entityClass,
       (cb, root) -> filterResolver.buildPredicates(querySpec, cb, root, ids, idName),
       (cb, root) -> DinaFilterResolver.getOrders(querySpec, cb, root),
-      (int) querySpec.getOffset(),
+      Math.toIntExact(querySpec.getOffset()),
       Optional.ofNullable(querySpec.getLimit()).orElse(DEFAULT_LIMIT).intValue());
 
     Set<String> includedRelations = querySpec.getIncludedRelations()

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -430,13 +430,17 @@ public class DinaRepository<D, E extends DinaEntity>
   @SneakyThrows
   @Override
   public ResourceIdentifier modifyOneRelationship(
-    Object o,
+    Object dto,
     ResourceField resourceField,
     ResourceIdentifier resourceIdentifier
   ) {
-    Object relation = resourceField.getType().getConstructor().newInstance();
-    PropertyUtils.setProperty(relation, "uuid", UUID.fromString(resourceIdentifier.getId()));
-    PropertyUtils.setProperty(o, "task", relation);
+    String relationIdFieldName = this.resourceRegistry
+      .findEntry(resourceField.getElementType())
+      .getResourceInformation().getIdField().getUnderlyingName();
+
+    Object relation = resourceField.getElementType().getConstructor().newInstance();
+    PropertyUtils.setProperty(relation, relationIdFieldName, UUID.fromString(resourceIdentifier.getId()));
+    PropertyUtils.setProperty(dto, resourceField.getUnderlyingName(), relation);
     return resourceIdentifier;
   }
 

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -292,9 +292,9 @@ public class DinaRepository<D, E extends DinaEntity>
 
   /**
    * Transverses a given class to return a map of fields per class parsed from the
-   * given class. Used to determine the nessesasry classes and fields per class
+   * given class. Used to determine the necessary classes and fields per class
    * when mapping a java bean. Fields marked with {@link JsonApiRelation} will be
-   * teated as seperate classes to map and will be transversed and mapped.
+   * treated as separate classes to map and will be transversed and mapped.
    *
    * @param <T>
    *                         - Type of class

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -75,8 +75,7 @@ public class DinaRepository<D, E extends DinaEntity>
   private final Map<Class<?>, Set<String>> resourceFieldsPerClass;
   private final Map<Class<?>, Set<String>> entityFieldsPerClass;
 
-  private static final int DEFAULT_OFFSET = 0;
-  private static final int DEFAULT_LIMIT = 100;
+  private static final long DEFAULT_LIMIT = 100;
 
   @Getter
   @Setter(onMethod_ = @Override)
@@ -143,8 +142,8 @@ public class DinaRepository<D, E extends DinaEntity>
       entityClass,
       (cb, root) -> filterResolver.buildPredicates(querySpec, cb, root, ids, idName),
       (cb, root) -> DinaFilterResolver.getOrders(querySpec, cb, root),
-      Optional.ofNullable(querySpec.getOffset()).orElse(Long.valueOf(DEFAULT_OFFSET)).intValue(),
-      Optional.ofNullable(querySpec.getLimit()).orElse(Long.valueOf(DEFAULT_LIMIT)).intValue());
+      (int) querySpec.getOffset(),
+      Optional.ofNullable(querySpec.getLimit()).orElse(DEFAULT_LIMIT).intValue());
 
     Set<String> includedRelations = querySpec.getIncludedRelations()
       .stream()

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/repository/DinaRepositoryIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/repository/DinaRepositoryIT.java
@@ -85,16 +85,6 @@ public class DinaRepositoryIT {
   }
 
   @Test
-  public void findOne_ExcludeRelations_RelationsExcluded() {
-    PersonDTO dto = persistPerson();
-
-    PersonDTO result = dinaRepository.findOne(dto.getUuid(), new QuerySpec(PersonDTO.class));
-    assertEqualsPersonDtos(dto, result, false);
-    assertNull(result.getDepartment());
-    assertNull(result.getDepartments());
-  }
-
-  @Test
   public void findOne_NoResourceFound_ThrowsResourceNotFoundException() {
     assertThrows(
       ResourceNotFoundException.class,

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/repository/DinaRepositoryIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/repository/DinaRepositoryIT.java
@@ -93,26 +93,6 @@ public class DinaRepositoryIT {
   }
 
   @Test
-  public void findAll_NoFilters_FindsAllAndExcludesRelationships() {
-    Map<UUID, PersonDTO> expectedPersons = new HashMap<>();
-
-    for (int i = 0; i < 10; i++) {
-      PersonDTO dto = persistPerson();
-      expectedPersons.put(dto.getUuid(), dto);
-    }
-
-    List<PersonDTO> result = dinaRepository.findAll(null, new QuerySpec(PersonDTO.class));
-
-    assertEquals(expectedPersons.size(), result.size());
-    for (PersonDTO resultElement : result) {
-      PersonDTO expectedDto = expectedPersons.get(resultElement.getUuid());
-      assertEqualsPersonDtos(expectedDto, resultElement, false);
-      assertNull(resultElement.getDepartment());
-      assertNull(resultElement.getDepartments());
-    }
-  }
-
-  @Test
   public void findAll_ResourceAndRelations_FindsResourceAndRelations() {
     Map<UUID, PersonDTO> expectedPersons = new HashMap<>();
 


### PR DESCRIPTION
Major change is that DinaRepo.findAll will always return the relationships that are NOT included in the query spec in a shallow form (id only).

This allows the crnk pre patch operation for a Patch request to give the Repo.save() method the correct information needed to persist the correct state of a resource.

Implemented in the repo layer, handles relations that are collections.