### PR TITLE
20576 auditing relations error

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -5,8 +5,8 @@ import ca.gc.aafc.dina.entity.DinaEntity;
 import ca.gc.aafc.dina.filter.DinaFilterResolver;
 import ca.gc.aafc.dina.mapper.DerivedDtoField;
 import ca.gc.aafc.dina.mapper.DinaMapper;
-import ca.gc.aafc.dina.repository.meta.DinaMetaInfo;
 import ca.gc.aafc.dina.repository.external.ExternalResourceProvider;
+import ca.gc.aafc.dina.repository.meta.DinaMetaInfo;
 import ca.gc.aafc.dina.repository.meta.JsonApiExternalRelation;
 import ca.gc.aafc.dina.service.AuditService;
 import ca.gc.aafc.dina.service.DinaAuthorizationService;
@@ -243,6 +243,7 @@ public class DinaRepository<D, E extends DinaEntity>
 
     D dto = dinaMapper.toDto(entity, entityFieldsPerClass,
       relationFields.stream().map(ResourceField::getUnderlyingName).collect(Collectors.toSet()));
+    mapShallowRelations(entity, dto, relationFields);
     auditService.ifPresent(service -> service.audit(dto));
     return (S) dto;
   }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -246,6 +246,7 @@ public class DinaRepository<D, E extends DinaEntity>
     dinaService.create(entity);
 
     D dto = dinaMapper.toDto(entity, entityFieldsPerClass, relationsToMap);
+    mapShallowRelations(entity, dto, relationFields);
     auditService.ifPresent(service -> service.audit(dto));
 
     return (S) dto;

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/dto/DepartmentDto.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/dto/DepartmentDto.java
@@ -12,6 +12,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.javers.core.metamodel.annotation.Id;
+import org.javers.core.metamodel.annotation.PropertyName;
+import org.javers.core.metamodel.annotation.TypeName;
 
 @Data
 @JsonApiResource(type = "department")
@@ -19,9 +22,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @RelatedEntity(Department.class)
+@TypeName("department")
 public class DepartmentDto {
 
   @JsonApiId
+  @Id
+  @PropertyName("id")
   private UUID uuid;
 
   private String name;
@@ -31,7 +37,7 @@ public class DepartmentDto {
   @DerivedDtoField
   private Integer employeeCount;
 
-  @JsonApiRelation(opposite = "department")
+  @JsonApiRelation(mappedBy = "department")
   private List<EmployeeDto> employees;
 
 }


### PR DESCRIPTION
This fixes a small issue when creating a entity with a relationship that needs to be audited.

When the created resource is mapped back to its DTO form it requires the shallow ids of any relations that were created with it for the auditing operations.

This edge was never tested so the tests have also been slightly updated.