### PR TITLE
20632 external relation meta section fix

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -80,7 +80,7 @@ public class DinaRepository<D, E extends DinaEntity>
 
   private final Map<Class<?>, Set<String>> resourceFieldsPerClass;
   private final Map<Class<?>, Set<String>> entityFieldsPerClass;
-  private final Map<String, String> externalMetaMap;
+  private final List<Map<String, String>> externalMetaMap;
 
   private static final long DEFAULT_LIMIT = 100;
 
@@ -288,7 +288,7 @@ public class DinaRepository<D, E extends DinaEntity>
   ) {
     DinaMetaInfo metaInfo = new DinaMetaInfo();
     // Set External types
-    metaInfo.setExternalTypes(externalMetaMap);
+    metaInfo.setExternal(externalMetaMap);
     // Set resource counts
     if (metaInformation instanceof PagedMetaInformation) {
       PagedMetaInformation pagedMetaInformation = (PagedMetaInformation) metaInformation;

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/meta/DinaMetaInfo.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/meta/DinaMetaInfo.java
@@ -2,29 +2,26 @@ package ca.gc.aafc.dina.repository.meta;
 
 import ca.gc.aafc.dina.repository.external.ExternalResourceProvider;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.common.collect.ImmutableMap;
 import io.crnk.core.resource.meta.DefaultPagedMetaInformation;
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import org.apache.commons.lang3.reflect.FieldUtils;
 
+import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
  * Meta information to be returned in a JSON response.
  */
+@Getter
+@Setter
 public class DinaMetaInfo extends DefaultPagedMetaInformation {
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
-  private Map<String, String> externalTypes;
-
-  public Map<String, String> getExternalTypes() {
-    return externalTypes;
-  }
-
-  public void setExternalTypes(Map<String, String> externalTypes) {
-    this.externalTypes = externalTypes;
-  }
+  private List<Map<String, String>> external;
 
   /**
    * Returns a map of a given classes {@link JsonApiExternalRelation} types mapped to their current
@@ -35,7 +32,7 @@ public class DinaMetaInfo extends DefaultPagedMetaInformation {
    * @return Returns a map of a given classes {@link JsonApiExternalRelation} types mapped to their
    * current reference
    */
-  public static Map<String, String> parseExternalTypes(
+  public static List<Map<String, String>> parseExternalTypes(
     @NonNull Class<?> clazz,
     @NonNull ExternalResourceProvider provider
   ) {
@@ -43,6 +40,8 @@ public class DinaMetaInfo extends DefaultPagedMetaInformation {
       .stream()
       .map(field -> field.getAnnotation(JsonApiExternalRelation.class).type())
       .distinct()
-      .collect(Collectors.toMap(Function.identity(), provider::getReferenceForType));
+      .map(s -> ImmutableMap.of("type", s, "href", provider.getReferenceForType(s)))
+      .collect(Collectors.toList());
   }
+
 }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/meta/DinaMetaInfo.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/meta/DinaMetaInfo.java
@@ -2,7 +2,6 @@ package ca.gc.aafc.dina.repository.meta;
 
 import ca.gc.aafc.dina.repository.external.ExternalResourceProvider;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.google.common.collect.ImmutableMap;
 import io.crnk.core.resource.meta.DefaultPagedMetaInformation;
 import lombok.Getter;
 import lombok.NonNull;
@@ -40,7 +39,7 @@ public class DinaMetaInfo extends DefaultPagedMetaInformation {
       .stream()
       .map(field -> field.getAnnotation(JsonApiExternalRelation.class).type())
       .distinct()
-      .map(s -> ImmutableMap.of("type", s, "href", provider.getReferenceForType(s)))
+      .map(s -> Map.of("type", s, "href", provider.getReferenceForType(s)))
       .collect(Collectors.toList());
   }
 

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoRestIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoRestIT.java
@@ -143,15 +143,18 @@ public class DinaRepoRestIT extends BaseRestAssuredTest {
 
   @Test
   void metaInfo_find_metaInfoContainsExternalRelation() {
-    ValidatableResponse findOne = super.sendGet(
+    validateMetaOfResponse(super.sendGet(
       ProjectDTO.RESOURCE_TYPE,
-      sendProjectByOperations(sendTask()).getUuid().toString());
-    ValidatableResponse findAll = super.sendGet(ProjectDTO.RESOURCE_TYPE, "");
-    findOne.body("meta.external[0].type", Matchers.equalTo("agent"));
-    findOne.body("meta.external[0].href", Matchers.equalTo(
+      sendProjectByOperations(sendTask()).getUuid().toString()));
+    validateMetaOfResponse(super.sendGet(ProjectDTO.RESOURCE_TYPE, ""));
+  }
+
+  private static void validateMetaOfResponse(ValidatableResponse response) {
+    response.body("meta.external[0].type", Matchers.equalTo("agent"));
+    response.body("meta.external[0].href", Matchers.equalTo(
       ExternalResourceProviderImplementation.typeToReferenceMap.get("agent")));
-    findOne.body("meta.external[1].type", Matchers.equalTo("author"));
-    findOne.body("meta.external[1].href", Matchers.equalTo(
+    response.body("meta.external[1].type", Matchers.equalTo("author"));
+    response.body("meta.external[1].href", Matchers.equalTo(
       ExternalResourceProviderImplementation.typeToReferenceMap.get("author")));
   }
 

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoRestIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/jsonapi/DinaRepoRestIT.java
@@ -147,11 +147,12 @@ public class DinaRepoRestIT extends BaseRestAssuredTest {
       ProjectDTO.RESOURCE_TYPE,
       sendProjectByOperations(sendTask()).getUuid().toString());
     ValidatableResponse findAll = super.sendGet(ProjectDTO.RESOURCE_TYPE, "");
-    ExternalResourceProviderImplementation.typeToReferenceMap.forEach((key, value) ->
-    {
-      findOne.body("meta.externalTypes." + key, Matchers.equalTo(value));
-      findAll.body("meta.externalTypes." + key, Matchers.equalTo(value));
-    });
+    findOne.body("meta.external[0].type", Matchers.equalTo("agent"));
+    findOne.body("meta.external[0].href", Matchers.equalTo(
+      ExternalResourceProviderImplementation.typeToReferenceMap.get("agent")));
+    findOne.body("meta.external[1].type", Matchers.equalTo("author"));
+    findOne.body("meta.external[1].href", Matchers.equalTo(
+      ExternalResourceProviderImplementation.typeToReferenceMap.get("author")));
   }
 
   @Test
@@ -159,7 +160,7 @@ public class DinaRepoRestIT extends BaseRestAssuredTest {
     ValidatableResponse validatableResponse = super.sendGet(
       TaskDTO.RESOURCE_TYPE,
       sendTask().getUuid().toString());
-    validatableResponse.body("meta.externalTypes", Matchers.nullValue());
+    validatableResponse.body("meta.external", Matchers.nullValue());
   }
 
   @Test


### PR DESCRIPTION
Fixes external relation section in meta to conform with the specs

```
"external": [
            {
                "type": "agent",
                "href": "Agent/api/v1/agent"
            },
            {
                "type": "author",
                "href": "Author/api/v1/author"
            }
        ]
```