### PR TITLE
20581 improve external type resolvers

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
@@ -218,7 +218,7 @@ public class DinaMapper<D, E> {
         Object targetRelation = null;
 
         if (sourceRelation != null) {
-          if (registry.isRelationCollection(relationFieldName)) {
+          if (registry.isRelationCollection(source.getClass(), relationFieldName)) {
             targetRelation = ((Collection<?>) sourceRelation).stream()
               .map(ele -> mapRelation(fieldsPerClass, ele, targetType, currentVisited))
               .collect(Collectors.toCollection(ArrayList::new));

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
@@ -49,7 +49,7 @@ public class DinaMapper<D, E> {
    *
    * @param dtoClass - class to map
    */
-  public DinaMapper(@NonNull Class<D> dtoClass) {
+  public DinaMapper(Class<D> dtoClass) {
     this(dtoClass, new HashMap<>(), new DinaMappingRegistry(dtoClass));
     initMaps(dtoClass);
   }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
@@ -338,7 +338,7 @@ public class DinaMapper<D, E> {
    * @return class of the paramterized type at the first position
    */
   @SneakyThrows
-  private static Class<?> getGenericType(Class<?> source, String fieldName) {
+  public static Class<?> getGenericType(Class<?> source, String fieldName) {
     ParameterizedType genericType = (ParameterizedType) source
         .getDeclaredField(fieldName)
         .getGenericType();
@@ -368,7 +368,7 @@ public class DinaMapper<D, E> {
    *                - class to check
    * @return true if the given class is a collection
    */
-  private static boolean isCollection(Class<?> clazz) {
+  public static boolean isCollection(Class<?> clazz) {
     return Collection.class.isAssignableFrom(clazz);
   }
 

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMapper.java
@@ -11,14 +11,12 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.hibernate.Hibernate;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -36,7 +34,6 @@ public class DinaMapper<D, E> {
 
   private final Class<D> dtoClass;
   private final Map<Class<?>, CustomFieldHandler<?, ?>> handlers;
-  private final Map<Class<?>, Set<String>> fieldsPerClass;
   private final DinaMappingRegistry registry;
 
   /**
@@ -53,13 +50,12 @@ public class DinaMapper<D, E> {
    * @param dtoClass - class to map
    */
   public DinaMapper(@NonNull Class<D> dtoClass) {
-    this(dtoClass, new HashMap<>(), new HashMap<>(), new DinaMappingRegistry(dtoClass));
+    this(dtoClass, new HashMap<>(), new DinaMappingRegistry(dtoClass));
     initMaps(dtoClass);
   }
 
   private void initMaps(Class<D> dtoClass) {
     Set<Class<?>> dtoClasses = parseGraph(dtoClass);
-
     for (Class<?> dto : dtoClasses) {
       RelatedEntity annotation = dto.getAnnotation(RelatedEntity.class);
 
@@ -68,9 +64,6 @@ public class DinaMapper<D, E> {
         CustomFieldHandler<?, ?> handler = new CustomFieldHandler<>(dto, relatedEntity);
         handlers.put(dto, handler);
         handlers.put(relatedEntity, handler);
-
-        fieldsPerClass.put(dto, parseFieldNames(dto));
-        fieldsPerClass.put(relatedEntity, parseFieldNames(relatedEntity));
       }
     }
   }
@@ -79,14 +72,16 @@ public class DinaMapper<D, E> {
     return parseGraph(dto, new HashSet<>());
   }
 
+  @SneakyThrows
   private Set<Class<?>> parseGraph(Class<?> dto, Set<Class<?>> visited) {
     if (visited.contains(dto)) {
       return visited;
     }
     visited.add(dto);
 
-    for (Field f : getRelations(dto)) {
-      Class<?> dtoType = isCollection(f.getType()) ? getGenericType(dto, f.getName()) : f.getType();
+    for (Field f : FieldUtils.getFieldsListWithAnnotation(dto, JsonApiRelation.class)) {
+      Class<?> dtoType = DinaMappingRegistry.getResolvedType(
+        dto.getConstructor().newInstance(), f.getName());
       parseGraph(dtoType, visited);
     }
     return visited;
@@ -213,19 +208,17 @@ public class DinaMapper<D, E> {
   ) {
     for (String relationFieldName : relations) {
       if (!hasResolvers(relationFieldName, source.getClass())
-          && containsField(relationFieldName, source.getClass(), target.getClass())) {
+          && containsRelation(relationFieldName, source.getClass(), target.getClass())) {
 
         // Each relation requires a separate tracking set
         Map<Object, Object> currentVisited = new IdentityHashMap<>(visited);
 
-        Class<?> sourceRelationType = PropertyUtils.getPropertyType(source, relationFieldName);
-        Class<?> targetType = getResolvedType(target, relationFieldName);
-
+        Class<?> targetType = DinaMappingRegistry.getResolvedType(target, relationFieldName);
         Object sourceRelation = PropertyUtils.getProperty(source, relationFieldName);
         Object targetRelation = null;
 
         if (sourceRelation != null) {
-          if (isCollection(sourceRelationType)) {
+          if (registry.isRelationCollection(relationFieldName)) {
             targetRelation = ((Collection<?>) sourceRelation).stream()
               .map(ele -> mapRelation(fieldsPerClass, ele, targetType, currentVisited))
               .collect(Collectors.toCollection(ArrayList::new));
@@ -311,77 +304,17 @@ public class DinaMapper<D, E> {
   }
 
   /**
-   * Returns the class of the paramterized type at the first position of a given class's given
-   * field.
-   * <p>
-   * given class is assumed to be a {@link ParameterizedType}
-   *
-   * @param source    given class
-   * @param fieldName field name of the given class to parse
-   * @return class of the paramterized type at the first position
-   */
-  @SneakyThrows
-  public static Class<?> getGenericType(Class<?> source, String fieldName) {
-    ParameterizedType genericType = (ParameterizedType) source
-      .getDeclaredField(fieldName)
-      .getGenericType();
-    return (Class<?>) genericType.getActualTypeArguments()[0];
-  }
-
-  /**
-   * Returns the resolved type of a fieldname for a given source. If the type is a collection, the
-   * first generic type is returned.
-   *
-   * @param source    - source object of the field
-   * @param fieldName - field name
-   * @return Field type or the first genric type if the field is a collection
-   */
-  @SneakyThrows
-  private static Class<?> getResolvedType(Object source, String fieldName) {
-    Class<?> propertyType = PropertyUtils.getPropertyType(source, fieldName);
-    return isCollection(propertyType) ? getGenericType(source.getClass(), fieldName) : propertyType;
-  }
-
-  /**
-   * Returns true if the given class is a collection
-   *
-   * @param clazz - class to check
-   * @return true if the given class is a collection
-   */
-  public static boolean isCollection(Class<?> clazz) {
-    return Collection.class.isAssignableFrom(clazz);
-  }
-
-  /**
-   * Returns the JsonApiRelations for a given class.
-   *
-   * @param cls - class to parse
-   * @return JsonApiRelations for a given class
-   */
-  private static List<Field> getRelations(Class<?> cls) {
-    return FieldUtils.getFieldsListWithAnnotation(cls, JsonApiRelation.class);
-  }
-
-  /**
-   * Returns a set of field names for a given class.
-   *
-   * @param cls - class to parse
-   * @return set of field names for a given class.
-   */
-  private static Set<String> parseFieldNames(Class<?> cls) {
-    return Stream.of(cls.getDeclaredFields()).map(Field::getName).collect(Collectors.toSet());
-  }
-
-  /**
-   * Returns true if the given classes all contain the given field.
+   * Returns true if the given classes all contain the given relation.
    *
    * @param field   field to check
    * @param classes classes to check
    * @return true if the given classes all contain the given field.
    */
-  private boolean containsField(String field, Class<?>... classes) {
+  private boolean containsRelation(String field, Class<?>... classes) {
     return Stream.of(classes).allMatch(aClass ->
-      fieldsPerClass.containsKey(aClass) && fieldsPerClass.get(aClass).contains(field));
+      registry.findMappableRelationsForClass(aClass) != null &&
+      registry.findMappableRelationsForClass(aClass).stream().anyMatch(field::equalsIgnoreCase)
+    );
   }
 
   /**
@@ -392,7 +325,6 @@ public class DinaMapper<D, E> {
    * @return rue if the given class and field have custom field resolvers tracked by the mapper.
    */
   private boolean hasResolvers(String field, Class<?> aClass) {
-    return handlers.containsKey(aClass)
-           && handlers.get(aClass).hasCustomFieldResolver(field);
+    return handlers.containsKey(aClass) && handlers.get(aClass).hasCustomFieldResolver(field);
   }
 }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
@@ -34,9 +34,9 @@ public class DinaMappingLayer<D, E> {
   }
 
   /**
-   * Returns a list of resources mapped from the given entities. Relations included in the query spec
-   * are fully mapped. External relations are always mapped. Relations not included in the query
-   * spec are shallow mapped (natural id only).
+   * Returns a list of resources mapped from the given entities. Relations included in the query
+   * spec are fully mapped. External relations are always mapped. Relations not included in the
+   * query spec are shallow mapped (natural id only).
    *
    * @param query    - query spec of the request
    * @param entities - entities to map
@@ -172,7 +172,7 @@ public class DinaMappingLayer<D, E> {
     for (Map.Entry<String, Class<?>> relation : relations.entrySet()) {
       String relationName = relation.getKey();
       Class<?> relationType = relation.getValue();
-      if (registry.isRelationCollection(relationName)) {
+      if (registry.isRelationCollection(source.getClass(), relationName)) {
         Collection<?> relationValue = (Collection<?>) PropertyUtils.getProperty(
           source, relationName);
         if (relationValue != null) {

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
@@ -33,6 +33,15 @@ public class DinaMappingLayer<D, E> {
     this.registry = new DinaMappingRegistry(resourceClass);
   }
 
+  /**
+   * Returns a list of resources mapped from the given entities. Relations included in the query spec
+   * are fully mapped. External relations are always mapped. Relations not included in the query
+   * spec are shallow mapped (natural id only).
+   *
+   * @param query    - query spec of the request
+   * @param entities - entities to map
+   * @return - list of resources.
+   */
   public List<D> mapEntitiesToDto(@NonNull QuerySpec query, @NonNull List<E> entities) {
     Set<String> includedRelations = query.getIncludedRelations().stream()
       .map(ir -> ir.getAttributePath().get(0))
@@ -56,6 +65,14 @@ public class DinaMappingLayer<D, E> {
       .collect(Collectors.toList());
   }
 
+  /**
+   * Maps a given dto to a given entity. All external/internal relations are mapped, relations are
+   * linked to their database backed resource if they are not external.
+   *
+   * @param dto    - source of the mapping
+   * @param entity - target of the mapping
+   * @param <S>    dto type
+   */
   public <S extends D> void mapToEntity(@NonNull S dto, @NonNull E entity) {
     // Bean mapping
     dinaMapper.applyDtoToEntity(
@@ -68,10 +85,22 @@ public class DinaMappingLayer<D, E> {
     mapExternalRelationsToEntity(dto, entity);
   }
 
+  /**
+   * Returns a new dto with only the attributes mapped from a given entity.
+   *
+   * @param entity - source of the mapping
+   * @return a new dto mapped from a given source
+   */
   public D mapForDelete(@NonNull E entity) {
     return dinaMapper.toDto(entity, registry.getEntityFieldsPerClass(), Collections.emptySet());
   }
 
+  /**
+   * Maps the external relations from the given source to the given target
+   *
+   * @param source - source of the external relations
+   * @param target - target of the mapping
+   */
   private void mapExternalRelationsToDto(E source, D target) {
     registry.getExternalRelations().forEach(external -> {
       Object id = PropertyUtils.getProperty(source, external);
@@ -85,6 +114,12 @@ public class DinaMappingLayer<D, E> {
     });
   }
 
+  /**
+   * Maps the external relations from the given source to the given target.
+   *
+   * @param source - source of the external relations
+   * @param target - target of the mapping
+   */
   private void mapExternalRelationsToEntity(D source, E target) {
     registry.getExternalRelations().forEach(external -> {
       Object externalRelation = PropertyUtils.getProperty(source, external);

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
@@ -4,12 +4,9 @@ import ca.gc.aafc.dina.dto.ExternalRelationDto;
 import ca.gc.aafc.dina.service.DinaService;
 import io.crnk.core.engine.internal.utils.PropertyUtils;
 import io.crnk.core.queryspec.QuerySpec;
-import io.crnk.core.resource.annotations.JsonApiId;
 import lombok.NonNull;
 import lombok.SneakyThrows;
-import org.apache.commons.lang3.reflect.FieldUtils;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -96,7 +93,8 @@ public class DinaMappingLayer<D, E> {
    */
   private void mapShallowRelations(E entity, D dto, @NonNull Map<String, Class<?>> relations) {
     mapRelations(entity, dto, relations,
-      (aClass, relation) -> createShallowDTO(findIdFieldName(aClass), aClass, relation));
+      (aClass, relation) ->
+        createShallowDTO(registry.getJsonIdFieldNamePerClass().get(aClass), aClass, relation));
   }
 
   /**
@@ -108,7 +106,8 @@ public class DinaMappingLayer<D, E> {
    */
   private void linkRelations(@NonNull E entity, @NonNull Map<String, Class<?>> relations) {
     mapRelations(entity, entity, relations,
-      (aClass, relation) -> returnPersistedObject(findIdFieldName(aClass), relation));
+      (aClass, relation) ->
+        returnPersistedObject(registry.getJsonIdFieldNamePerClass().get(aClass), relation));
   }
 
   /**
@@ -173,18 +172,6 @@ public class DinaMappingLayer<D, E> {
   private Object returnPersistedObject(String idFieldName, Object object) {
     Object relationID = PropertyUtils.getProperty(object, idFieldName);
     return dinaService.findOneReferenceByNaturalId(object.getClass(), relationID);
-  }
-
-  /**
-   * Returns the id field name for a given class.
-   *
-   * @param clazz - class to find the id field name for
-   * @return - id field name for a given class.
-   */
-  private String findIdFieldName(Class<?> clazz) {
-    return Arrays.stream(FieldUtils.getFieldsWithAnnotation(clazz, JsonApiId.class))
-      .findAny().orElseThrow(() -> new IllegalArgumentException(""))
-      .getName();
   }
 
   private boolean isNotExternal(String field) {

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
@@ -172,7 +172,7 @@ public class DinaMappingLayer<D, E> {
     for (Map.Entry<String, Class<?>> relation : relations.entrySet()) {
       String relationName = relation.getKey();
       Class<?> relationType = relation.getValue();
-      if (registry.isCollection(relationName)) {
+      if (registry.isRelationCollection(relationName)) {
         Collection<?> relationValue = (Collection<?>) PropertyUtils.getProperty(
           source, relationName);
         if (relationValue != null) {

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
@@ -1,0 +1,323 @@
+package ca.gc.aafc.dina.mapper;
+
+import ca.gc.aafc.dina.dto.RelatedEntity;
+import ca.gc.aafc.dina.repository.meta.JsonApiExternalRelation;
+import ca.gc.aafc.dina.service.DinaService;
+import io.crnk.core.engine.information.resource.ResourceField;
+import io.crnk.core.engine.internal.utils.PropertyUtils;
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.resource.annotations.JsonApiId;
+import io.crnk.core.resource.annotations.JsonApiRelation;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.reflect.FieldUtils;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class DinaMappingLayer<D, E> {
+
+  private final Class<D> resourceClass;
+  private final Map<Class<?>, Set<String>> resourceFieldsPerClass;
+  private final Map<Class<?>, Set<String>> entityFieldsPerClass;
+  private final DinaMapper<D, E> dinaMapper;
+  private final DinaService<?> dinaService;
+
+  public DinaMappingLayer(
+    @NonNull Class<D> resourceClass,
+    @NonNull DinaService<?> dinaService,
+    @NonNull DinaMapper<D, E> dinaMapper
+  ) {
+    this.resourceClass = resourceClass;
+    this.resourceFieldsPerClass =
+      parseFieldsPerClass(resourceClass, new HashMap<>(), DinaMappingLayer::isNotMappable);
+    this.entityFieldsPerClass = getFieldsPerEntity();
+    this.dinaService = dinaService;
+    this.dinaMapper = dinaMapper;
+  }
+
+  public List<D> mapEntitiesToDto(
+    QuerySpec querySpec,
+    List<E> returnedEntities,
+    List<ResourceField> relations
+  ) {
+    Set<String> relationsToMap = Stream.concat(
+      querySpec.getIncludedRelations().stream().map(ir -> ir.getAttributePath().get(0)),
+      FieldUtils.getFieldsListWithAnnotation(resourceClass, JsonApiExternalRelation.class)
+        .stream().map(Field::getName)
+    ).collect(Collectors.toSet());
+
+    List<ResourceField> shallowRelationsToMap = relations.stream()
+      .filter(rel -> relationsToMap.stream().noneMatch(rel.getUnderlyingName()::equalsIgnoreCase))
+      .collect(Collectors.toList());
+
+    return returnedEntities.stream()
+      .map(e -> {
+        D dto = dinaMapper.toDto(e, entityFieldsPerClass, relationsToMap);
+        mapShallowRelations(e, dto, shallowRelationsToMap);
+        return dto;
+      })
+      .collect(Collectors.toList());
+  }
+
+  public <S extends D> void mapToEntity(S dto, E entity, List<ResourceField> relationFields) {
+    Set<String> relationsToMap = relationFields.stream()
+      .map(ResourceField::getUnderlyingName).collect(Collectors.toSet());
+    dinaMapper.applyDtoToEntity(dto, entity, resourceFieldsPerClass, relationsToMap);
+
+    List<ResourceField> relationsToLink = relationFields.stream()
+      .filter(relation ->
+        !hasAnnotation(resourceClass, relation.getUnderlyingName(), JsonApiExternalRelation.class))
+      .collect(Collectors.toList());
+    linkRelations(entity, relationsToLink);
+  }
+
+  public D mapForDelete(E entity) {
+    return dinaMapper.toDto(entity, entityFieldsPerClass, Collections.emptySet());
+  }
+
+  /**
+   * Transverses a given class to return a map of fields per class parsed from the given class. Used
+   * to determine the necessary classes and fields per class when mapping a java bean. Fields marked
+   * with {@link JsonApiRelation} will be treated as separate classes to map and will be transversed
+   * and mapped.
+   *
+   * @param <T>            - Type of class
+   * @param clazz          - Class to parse
+   * @param fieldsPerClass - initial map to use
+   * @param ignoreIf       - predicate to return true for fields to be removed
+   * @return a map of fields per class
+   */
+  @SneakyThrows
+  private static <T> Map<Class<?>, Set<String>> parseFieldsPerClass(
+    @NonNull Class<T> clazz,
+    @NonNull Map<Class<?>, Set<String>> fieldsPerClass,
+    @NonNull Predicate<Field> ignoreIf
+  ) {
+    if (fieldsPerClass.containsKey(clazz)) {
+      return fieldsPerClass;
+    }
+
+    List<Field> relationFields = FieldUtils.getFieldsListWithAnnotation(
+      clazz,
+      JsonApiRelation.class
+    );
+
+    List<Field> attributeFields = FieldUtils.getAllFieldsList(clazz).stream()
+      .filter(f -> !relationFields.contains(f) && !f.isSynthetic() && !ignoreIf.test(f))
+      .collect(Collectors.toList());
+
+    Set<String> fieldsToInclude = attributeFields.stream()
+      .map(Field::getName)
+      .collect(Collectors.toSet());
+
+    fieldsPerClass.put(clazz, fieldsToInclude);
+
+    parseRelations(clazz, fieldsPerClass, relationFields, ignoreIf);
+
+    return fieldsPerClass;
+  }
+
+  /**
+   * Helper method to parse the fields of a given list of relations and add them to a given map.
+   *
+   * @param <T>            - Type of class
+   * @param clazz          - class containing the relations
+   * @param fieldsPerClass - map to add to
+   * @param relationFields - relation fields to transverse
+   */
+  @SneakyThrows
+  private static <T> void parseRelations(
+    Class<T> clazz,
+    Map<Class<?>, Set<String>> fieldsPerClass,
+    List<Field> relationFields,
+    Predicate<Field> removeIf
+  ) {
+    for (Field relationField : relationFields) {
+      if (Collection.class.isAssignableFrom(relationField.getType())) {
+        ParameterizedType genericType = (ParameterizedType) clazz
+          .getDeclaredField(relationField.getName())
+          .getGenericType();
+        for (Type elementType : genericType.getActualTypeArguments()) {
+          parseFieldsPerClass((Class<?>) elementType, fieldsPerClass, removeIf);
+        }
+      } else {
+        parseFieldsPerClass(relationField.getType(), fieldsPerClass, removeIf);
+      }
+    }
+  }
+
+  /**
+   * Returns a map of fields per entity class.
+   *
+   * @return a map of fields per entity class.
+   */
+  private Map<Class<?>, Set<String>> getFieldsPerEntity() {
+    return resourceFieldsPerClass.entrySet()
+      .stream()
+      .filter(e -> getRelatedEntity(e.getKey()) != null)
+      .map(e -> new AbstractMap.SimpleEntry<>(getRelatedEntity(e.getKey()).value(), e.getValue()))
+      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  /**
+   * Returns a Dto's related entity (Marked with {@link RelatedEntity}) or else null.
+   *
+   * @param <T>   - Class type
+   * @param clazz - Class with a related entity.
+   * @return a Dto's related entity, or else null
+   */
+  private static <T> RelatedEntity getRelatedEntity(Class<T> clazz) {
+    return clazz.getAnnotation(RelatedEntity.class);
+  }
+
+  /**
+   * Returns true if the dina repo should not map the given field. currently that means if the field
+   * is generated (Marked with {@link DerivedDtoField}) or final.
+   *
+   * @param field - field to evaluate
+   * @return - true if the dina repo should not map the given field
+   */
+  private static boolean isNotMappable(Field field) {
+    return hasAnnotation(field.getDeclaringClass(), field.getName(), DerivedDtoField.class)
+           || Modifier.isFinal(field.getModifiers());
+  }
+
+  /**
+   * Returns true if the given class has a given field with an annotation of a given type.
+   *
+   * @param <T>             - Class type
+   * @param clazz           - class of the field
+   * @param field           - field to check
+   * @param annotationClass - annotation that is present
+   * @return true if a dto field is generated and read-only
+   */
+  @SneakyThrows(NoSuchFieldException.class)
+  private static <T> boolean hasAnnotation(
+    Class<T> clazz,
+    String field,
+    Class<? extends Annotation> annotationClass
+  ) {
+    return clazz.getDeclaredField(field).isAnnotationPresent(annotationClass);
+  }
+
+  /**
+   * Maps the given relations from the given entity to a given dto in a shallow form (Id only).
+   *
+   * @param entity         - source of the mapping
+   * @param dto            - target of the mapping
+   * @param relationsToMap - relations to map
+   */
+  private void mapShallowRelations(E entity, D dto, List<ResourceField> relationsToMap) {
+    mapRelations(entity, dto, relationsToMap,
+      (resourceField, relation) -> {
+        Class<?> elementType = resourceField.getElementType();
+        return createShallowDTO(findIdFieldName(elementType), elementType, relation);
+      });
+  }
+
+  /**
+   * Replaces the given relations of given entity with there JPA entity equivalent. Relations id's
+   * are used to map a relation to its JPA equivalent.
+   *
+   * @param entity    - entity containing the relations
+   * @param relations - list of relations to map
+   */
+  private void linkRelations(@NonNull E entity, @NonNull List<ResourceField> relations) {
+    mapRelations(entity, entity, relations,
+      (resourceField, relation) ->
+        returnPersistedObject(findIdFieldName(resourceField.getElementType()), relation));
+  }
+
+  /**
+   * Maps the given relations from a given source to a given target with a given mapping function.
+   *
+   * @param source    - source of the mapping
+   * @param target    - target of the mapping
+   * @param relations - relations to map
+   * @param mapper    - mapping function to apply
+   */
+  private void mapRelations(
+    Object source,
+    Object target,
+    List<ResourceField> relations,
+    BiFunction<ResourceField, Object, Object> mapper
+  ) {
+    for (ResourceField relation : relations) {
+      String fieldName = relation.getUnderlyingName();
+      if (relation.isCollection()) {
+        Collection<?> relationValue = (Collection<?>) PropertyUtils.getProperty(source, fieldName);
+        if (relationValue != null) {
+          Collection<?> mappedCollection = relationValue.stream()
+            .map(rel -> mapper.apply(relation, rel))
+            .collect(Collectors.toList());
+          PropertyUtils.setProperty(target, fieldName, mappedCollection);
+        }
+      } else {
+        Object relationValue = PropertyUtils.getProperty(source, fieldName);
+        if (relationValue != null) {
+          Object mappedRelation = mapper.apply(relation, relationValue);
+          PropertyUtils.setProperty(target, fieldName, mappedRelation);
+        }
+      }
+    }
+  }
+
+  /**
+   * Maps the given id field name from a given entity to a new instance of a given type.
+   *
+   * @param idFieldName - name of the id field for the mapping
+   * @param type        - type of new instance to return with the mapping
+   * @param entity      - entity with the id to map
+   * @return - a new instance of a given type with a id value mapped from a given entity.
+   */
+  @SneakyThrows
+  private static Object createShallowDTO(String idFieldName, Class<?> type, Object entity) {
+    Object shallowDTO = type.getConstructor().newInstance();
+    PropertyUtils.setProperty(
+      shallowDTO,
+      idFieldName,
+      PropertyUtils.getProperty(entity, idFieldName));
+    return shallowDTO;
+  }
+
+  /**
+   * Returns the jpa entity representing a given object with an id field of a given id field name.
+   *
+   * @param idFieldName - name of the id field
+   * @param object      - object to map
+   * @return - jpa entity representing a given object
+   */
+  private Object returnPersistedObject(String idFieldName, Object object) {
+    Object relationID = PropertyUtils.getProperty(object, idFieldName);
+    return dinaService.findOneReferenceByNaturalId(object.getClass(), relationID);
+  }
+
+  /**
+   * Returns the id field name for a given class.
+   *
+   * @param clazz - class to find the id field name for
+   * @return - id field name for a given class.
+   */
+  private String findIdFieldName(Class<?> clazz) {
+    return Arrays.stream(FieldUtils.getFieldsWithAnnotation(clazz, JsonApiId.class))
+      .findAny().orElseThrow(() -> new IllegalArgumentException(""))
+      .getName();
+  }
+
+}

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
@@ -74,9 +74,14 @@ public class DinaMappingLayer<D, E> {
 
   private void mapExternalRelationsToDto(E source, D target) {
     registry.getExternalRelations().forEach(external -> {
-      String id = PropertyUtils.getProperty(source, external).toString();
-      PropertyUtils.setProperty(target, external,
-        ExternalRelationDto.builder().type(registry.findExternalType(external)).id(id).build());
+      Object id = PropertyUtils.getProperty(source, external);
+      if (id != null) {
+        PropertyUtils.setProperty(target, external,
+          ExternalRelationDto.builder()
+            .type(registry.findExternalType(external))
+            .id(id.toString())
+            .build());
+      }
     });
   }
 

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
@@ -115,6 +115,8 @@ public class DinaMappingLayer<D, E> {
             .type(registry.findExternalType(external))
             .id(id.toString())
             .build());
+      } else {
+        PropertyUtils.setProperty(target, external, null);
       }
     });
   }
@@ -132,6 +134,8 @@ public class DinaMappingLayer<D, E> {
         String jsonIdFieldName = registry.findJsonIdFieldName(ExternalRelationDto.class);
         PropertyUtils.setProperty(target, external,
           UUID.fromString(PropertyUtils.getProperty(externalRelation, jsonIdFieldName).toString()));
+      } else {
+        PropertyUtils.setProperty(target, external, null);
       }
     });
   }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
@@ -88,9 +88,11 @@ public class DinaMappingLayer<D, E> {
   private void mapExternalRelationsToEntity(D source, E target) {
     registry.getExternalRelations().forEach(external -> {
       Object externalRelation = PropertyUtils.getProperty(source, external);
-      String jsonIdFieldName = registry.findJsonIdFieldName(ExternalRelationDto.class);
-      PropertyUtils.setProperty(target, external,
-        UUID.fromString(PropertyUtils.getProperty(externalRelation, jsonIdFieldName).toString()));
+      if (externalRelation != null) {
+        String jsonIdFieldName = registry.findJsonIdFieldName(ExternalRelationDto.class);
+        PropertyUtils.setProperty(target, external,
+          UUID.fromString(PropertyUtils.getProperty(externalRelation, jsonIdFieldName).toString()));
+      }
     });
   }
 

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
@@ -47,7 +47,7 @@ public class DinaMappingLayer<D, E> {
       .map(ir -> ir.getAttributePath().get(0))
       .filter(Predicate.not(registry::isRelationExternal)).collect(Collectors.toSet());
 
-    Map<String, Class<?>> shallowRelationsToMap = registry.getMappableRelationsPerClass()
+    Map<String, Class<?>> shallowRelationsToMap = registry.getRelationTypesPerMappableRelation()
       .entrySet().stream()
       .filter(relation -> includedRelations.stream().noneMatch(relation.getKey()::equalsIgnoreCase))
       .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -78,9 +78,9 @@ public class DinaMappingLayer<D, E> {
     dinaMapper.applyDtoToEntity(
       dto, entity,
       registry.getResourceFieldsPerClass(),
-      registry.getMappableRelationsPerClass().keySet());
+      registry.getRelationTypesPerMappableRelation().keySet());
     // Link relations to Database backed resources
-    linkRelations(entity, registry.getMappableRelationsPerClass());
+    linkRelations(entity, registry.getRelationTypesPerMappableRelation());
     // Map External Relations
     mapExternalRelationsToEntity(dto, entity);
   }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingLayer.java
@@ -55,7 +55,7 @@ public class DinaMappingLayer<D, E> {
     return entities.stream()
       .map(e -> {
         // Bean mapping
-        D dto = dinaMapper.toDto(e, registry.getEntityFieldsPerClass(), includedRelations);
+        D dto = dinaMapper.toDto(e, registry.getAttributesPerClass(), includedRelations);
         // Map shallow ids fo un-included relations
         mapShallowRelations(e, dto, shallowRelationsToMap);
         // Map External Relations
@@ -77,7 +77,7 @@ public class DinaMappingLayer<D, E> {
     // Bean mapping
     dinaMapper.applyDtoToEntity(
       dto, entity,
-      registry.getResourceFieldsPerClass(),
+      registry.getAttributesPerClass(),
       registry.getRelationTypesPerMappableRelation().keySet());
     // Link relations to Database backed resources
     linkRelations(entity, registry.getRelationTypesPerMappableRelation());
@@ -92,7 +92,7 @@ public class DinaMappingLayer<D, E> {
    * @return a new dto mapped from a given source
    */
   public D mapForDelete(@NonNull E entity) {
-    return dinaMapper.toDto(entity, registry.getEntityFieldsPerClass(), Collections.emptySet());
+    return dinaMapper.toDto(entity, registry.getAttributesPerClass(), Collections.emptySet());
   }
 
   /**

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
@@ -114,8 +114,7 @@ public class DinaMappingRegistry {
 
     List<Field> allFieldsList = FieldUtils.getAllFieldsList(dtoClass);
     List<Field> relationFields = FieldUtils.getFieldsListWithAnnotation(
-      dtoClass,
-      JsonApiRelation.class);
+      dtoClass, JsonApiRelation.class);
 
     trackJsonId(dtoClass, allFieldsList);
     RelatedEntity relatedEntity = dtoClass.getAnnotation(RelatedEntity.class);

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
@@ -66,7 +66,8 @@ public class DinaMappingRegistry {
   }
 
   /**
-   * Returns the type of the given external relation field name if tracked by the registry.
+   * Returns the {@link JsonApiExternalRelation} type of the given external relation field name if
+   * tracked by the registry.
    *
    * @param relationFieldName - field name of the external relation.
    * @return type of the given external relation.

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
@@ -57,22 +57,15 @@ public class DinaMappingRegistry {
     this.jsonIdFieldNamePerClass = parseJsonIds(resourceClass, new HashMap<>(), new HashSet<>());
   }
 
+  /**
+   * Returns a set of the mappable relations for a given class, or null if a given class is not
+   * tracked.
+   *
+   * @param cls - class with relations
+   * @return Returns a set of the mappable relations for a given class.
+   */
   public Set<String> findMappableRelationsForClass(Class<?> cls) {
     return this.mappableRelationsPerClass.get(cls);
-  }
-
-  /**
-   * Returns the resolved type of a fieldname for a given source. If the type is a collection, the
-   * first generic type is returned.
-   *
-   * @param source    - source object of the field
-   * @param fieldName - field name
-   * @return Field type or the first genric type if the field is a collection
-   */
-  @SneakyThrows
-  public static Class<?> getResolvedType(Object source, String fieldName) {
-    Class<?> propertyType = PropertyUtils.getPropertyType(source, fieldName);
-    return isCollection(propertyType) ? getGenericType(source.getClass(), fieldName) : propertyType;
   }
 
   /**
@@ -123,6 +116,20 @@ public class DinaMappingRegistry {
    */
   public String findJsonIdFieldName(Class<?> cls) {
     return this.jsonIdFieldNamePerClass.get(cls);
+  }
+
+  /**
+   * Returns the resolved type of a fieldname for a given source. If the type is a collection, the
+   * first generic type is returned.
+   *
+   * @param source    - source object of the field
+   * @param fieldName - field name
+   * @return Field type or the first genric type if the field is a collection
+   */
+  @SneakyThrows
+  public static Class<?> getResolvedType(Object source, String fieldName) {
+    Class<?> propertyType = PropertyUtils.getPropertyType(source, fieldName);
+    return isCollection(propertyType) ? getGenericType(source.getClass(), fieldName) : propertyType;
   }
 
   private static Map<Class<?>, String> parseJsonIds(

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
@@ -144,10 +144,7 @@ public class DinaMappingRegistry {
 
   private void trackMappableRelations(Class<?> dto, Class<?> entity, List<Field> relations) {
     Set<InternalRelation> mappableRelations = relations.stream()
-      .filter(field ->
-        !field.isAnnotationPresent(JsonApiExternalRelation.class) &&
-        Stream.of(entity.getDeclaredFields())
-          .map(Field::getName).anyMatch(field.getName()::equalsIgnoreCase))
+      .filter(field -> isRelationMappable(dto, entity, field))
       .map(DinaMappingRegistry::mapToInternalRelation)
       .collect(Collectors.toSet());
     this.mappableRelationsPerClass.put(dto, mappableRelations);
@@ -194,6 +191,16 @@ public class DinaMappingRegistry {
     return !field.isAnnotationPresent(DerivedDtoField.class)
            && !Modifier.isFinal(field.getModifiers())
            && !field.isSynthetic();
+  }
+
+  private static boolean isRelationMappable(Class<?> dto, Class<?> entity, Field dtoRelationField) {
+    return !dtoRelationField.isAnnotationPresent(JsonApiExternalRelation.class) &&
+           Stream.of(entity.getDeclaredFields())
+             .map(Field::getName)
+             .anyMatch(dtoRelationField.getName()::equalsIgnoreCase) &&
+           Stream.of(dto.getDeclaredFields())
+             .map(Field::getName)
+             .anyMatch(dtoRelationField.getName()::equalsIgnoreCase);
   }
 
   /**

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
@@ -24,15 +24,20 @@ import java.util.stream.Collectors;
 
 public class DinaMappingRegistry {
 
+  // Tracks the resource graph for bean mapping
   @Getter
   private final Map<Class<?>, Set<String>> resourceFieldsPerClass;
+  // Tracks the entity graph for bean mapping
   @Getter
   private final Map<Class<?>, Set<String>> entityFieldsPerClass;
+  // Tracks the mappable relations
   @Getter
   private final Map<String, Class<?>> mappableRelationsPerClass;
-
+  // Tracks external relations field names to types for external relations mapping
   private final Map<String, String> externalNameToTypeMap;
+  // Tracks the name of relations which are collections
   private final Set<String> collectionBasedRelations;
+  // Track Json Id field names for mapping
   private final Map<Class<?>, String> jsonIdFieldNamePerClass;
 
   public DinaMappingRegistry(@NonNull Class<?> resourceClass) {
@@ -45,23 +50,52 @@ public class DinaMappingRegistry {
     this.jsonIdFieldNamePerClass = parseJsonIds(resourceClass, new HashMap<>());
   }
 
+  /**
+   * Returns the set of external relation field names tracked by the registry.
+   *
+   * @return set of external relation field names.
+   */
   public Set<String> getExternalRelations() {
     return this.externalNameToTypeMap.keySet();
   }
 
+  /**
+   * Returns the type of the given external relation if tracked by the registry otherwise null.
+   *
+   * @param relationFieldName - field name of the external relation.
+   * @return type of the given external relation.
+   */
   public String findExternalType(String relationFieldName) {
     return this.externalNameToTypeMap.get(relationFieldName);
   }
 
+  /**
+   * Returns true if the relation with the given field name is external.
+   *
+   * @param relationFieldName - field name of the external relation.
+   * @return Returns true if the relation with the given field name is external.
+   */
   public boolean isRelationExternal(String relationFieldName) {
     return this.externalNameToTypeMap.keySet().stream()
       .anyMatch(relationFieldName::equalsIgnoreCase);
   }
 
+  /**
+   * Returns true if the relation with a given field name is a Java Collection type.
+   *
+   * @param relationFieldName - field name of the relation.
+   * @return Returns true if the relation with a given field name is a Java Collection type.
+   */
   public boolean isCollection(String relationFieldName) {
     return this.collectionBasedRelations.stream().anyMatch(relationFieldName::equalsIgnoreCase);
   }
 
+  /**
+   * Returns the json id field name of a given class.
+   *
+   * @param cls - cls with json id field
+   * @return the json id field name of a given class.
+   */
   public String findJsonIdFieldName(Class<?> cls) {
     return this.jsonIdFieldNamePerClass.get(cls);
   }
@@ -192,11 +226,11 @@ public class DinaMappingRegistry {
   }
 
   /**
-   * Returns a Dto's related entity (Marked with {@link RelatedEntity}) or else null.
+   * Returns the related entity of a dto (Marked with {@link RelatedEntity}) or else null.
    *
    * @param <T>   - Class type
    * @param clazz - Class with a related entity.
-   * @return a Dto's related entity, or else null
+   * @return the related entity of a dto, or else null
    */
   private static <T> RelatedEntity parseRelatedEntity(Class<T> clazz) {
     return clazz.getAnnotation(RelatedEntity.class);

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
@@ -1,0 +1,163 @@
+package ca.gc.aafc.dina.mapper;
+
+import ca.gc.aafc.dina.dto.RelatedEntity;
+import ca.gc.aafc.dina.repository.meta.JsonApiExternalRelation;
+import io.crnk.core.resource.annotations.JsonApiRelation;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.reflect.FieldUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+@Getter
+public class DinaMappingRegistry {
+
+  private final Map<Class<?>, Set<String>> resourceFieldsPerClass;
+  private final Map<Class<?>, Set<String>> entityFieldsPerClass;
+  private final Map<String, String> externalNameToTypeMap;
+  private final Map<String, Class<?>> relationNamePerClass;
+  private final Set<String> collectionBasedRelations;
+
+  public DinaMappingRegistry(@NonNull Class<?> resourceClass) {
+    this.resourceFieldsPerClass =
+      parseFieldsPerClass(resourceClass, new HashMap<>(), DinaMappingRegistry::isNotMappable);
+    this.entityFieldsPerClass = parseFieldsPerEntity();
+    this.relationNamePerClass = FieldUtils
+      .getFieldsListWithAnnotation(resourceClass, JsonApiRelation.class).stream()
+      .filter(field -> !field.isAnnotationPresent(JsonApiExternalRelation.class))
+      .collect(Collectors.toMap(
+        Field::getName,
+        field -> DinaMapper.isCollection(field.getType()) ?
+          DinaMapper.getGenericType(field.getDeclaringClass(), field.getName()) : field.getType()));
+    this.collectionBasedRelations = FieldUtils
+      .getFieldsListWithAnnotation(resourceClass, JsonApiRelation.class)
+      .stream()
+      .filter(field -> DinaMapper.isCollection(field.getType()))
+      .map(Field::getName).collect(Collectors.toSet());
+    this.externalNameToTypeMap = FieldUtils
+      .getFieldsListWithAnnotation(resourceClass, JsonApiExternalRelation.class)
+      .stream().collect(Collectors.toMap(
+        Field::getName,
+        field -> field.getAnnotation(JsonApiExternalRelation.class).type()));
+  }
+
+  /**
+   * Returns true if the dina repo should not map the given field. currently that means if the field
+   * is generated (Marked with {@link DerivedDtoField}) or final.
+   *
+   * @param field - field to evaluate
+   * @return - true if the dina repo should not map the given field
+   */
+  private static boolean isNotMappable(Field field) {
+    return field.isAnnotationPresent(DerivedDtoField.class) ||
+           Modifier.isFinal(field.getModifiers());
+  }
+
+  /**
+   * Transverses a given class to return a map of fields per class parsed from the given class. Used
+   * to determine the necessary classes and fields per class when mapping a java bean. Fields marked
+   * with {@link JsonApiRelation} will be treated as separate classes to map and will be transversed
+   * and mapped.
+   *
+   * @param <T>            - Type of class
+   * @param clazz          - Class to parse
+   * @param fieldsPerClass - initial map to use
+   * @param ignoreIf       - predicate to return true for fields to be removed
+   * @return a map of fields per class
+   */
+  @SneakyThrows
+  private static <T> Map<Class<?>, Set<String>> parseFieldsPerClass(
+    @NonNull Class<T> clazz,
+    @NonNull Map<Class<?>, Set<String>> fieldsPerClass,
+    @NonNull Predicate<Field> ignoreIf
+  ) {
+    if (fieldsPerClass.containsKey(clazz)) {
+      return fieldsPerClass;
+    }
+
+    List<Field> relationFields = FieldUtils.getFieldsListWithAnnotation(
+      clazz,
+      JsonApiRelation.class
+    );
+
+    List<Field> attributeFields = FieldUtils.getAllFieldsList(clazz).stream()
+      .filter(f -> !relationFields.contains(f) && !f.isSynthetic() && !ignoreIf.test(f))
+      .collect(Collectors.toList());
+
+    Set<String> fieldsToInclude = attributeFields.stream()
+      .map(Field::getName)
+      .collect(Collectors.toSet());
+
+    fieldsPerClass.put(clazz, fieldsToInclude);
+
+    parseRelations(clazz, fieldsPerClass, relationFields, ignoreIf);
+
+    return fieldsPerClass;
+  }
+
+  /**
+   * Helper method to parse the fields of a given list of relations and add them to a given map.
+   *
+   * @param <T>            - Type of class
+   * @param clazz          - class containing the relations
+   * @param fieldsPerClass - map to add to
+   * @param relationFields - relation fields to transverse
+   */
+  @SneakyThrows
+  private static <T> void parseRelations(
+    Class<T> clazz,
+    Map<Class<?>, Set<String>> fieldsPerClass,
+    List<Field> relationFields,
+    Predicate<Field> removeIf
+  ) {
+    for (Field relationField : relationFields) {
+      if (Collection.class.isAssignableFrom(relationField.getType())) {
+        ParameterizedType genericType = (ParameterizedType) clazz
+          .getDeclaredField(relationField.getName())
+          .getGenericType();
+        for (Type elementType : genericType.getActualTypeArguments()) {
+          parseFieldsPerClass((Class<?>) elementType, fieldsPerClass, removeIf);
+        }
+      } else {
+        parseFieldsPerClass(relationField.getType(), fieldsPerClass, removeIf);
+      }
+    }
+  }
+
+  /**
+   * Returns a map of fields per entity class.
+   *
+   * @return a map of fields per entity class.
+   */
+  private Map<Class<?>, Set<String>> parseFieldsPerEntity() {
+    return resourceFieldsPerClass.entrySet()
+      .stream()
+      .filter(e -> parseRelatedEntity(e.getKey()) != null)
+      .map(e -> new AbstractMap.SimpleEntry<>(parseRelatedEntity(e.getKey()).value(), e.getValue()))
+      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  /**
+   * Returns a Dto's related entity (Marked with {@link RelatedEntity}) or else null.
+   *
+   * @param <T>   - Class type
+   * @param clazz - Class with a related entity.
+   * @return a Dto's related entity, or else null
+   */
+  private static <T> RelatedEntity parseRelatedEntity(Class<T> clazz) {
+    return clazz.getAnnotation(RelatedEntity.class);
+  }
+
+}

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
@@ -135,9 +135,7 @@ public class DinaMappingRegistry {
     List<Field> relationFields
   ) {
     Set<String> fieldsToInclude = allFieldsList.stream()
-      .filter(f -> !relationFields.contains(f) &&
-                   !f.isSynthetic() &&
-                   !DinaMappingRegistry.isNotMappable(f))
+      .filter(f -> !relationFields.contains(f) && DinaMappingRegistry.isFieldMappable(f))
       .map(Field::getName)
       .collect(Collectors.toSet());
     this.attributesPerClass.put(cls, fieldsToInclude);
@@ -192,9 +190,10 @@ public class DinaMappingRegistry {
    * @param field - field to evaluate
    * @return - true if the dina repo should not map the given field
    */
-  private static boolean isNotMappable(Field field) {
-    return field.isAnnotationPresent(DerivedDtoField.class) ||
-           Modifier.isFinal(field.getModifiers());
+  private static boolean isFieldMappable(Field field) {
+    return !field.isAnnotationPresent(DerivedDtoField.class)
+           && !Modifier.isFinal(field.getModifiers())
+           && !field.isSynthetic();
   }
 
   /**

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
@@ -66,12 +66,17 @@ public class DinaMappingRegistry {
   }
 
   /**
-   * Returns the type of the given external relation if tracked by the registry otherwise null.
+   * Returns the type of the given external relation field name if tracked by the registry.
    *
    * @param relationFieldName - field name of the external relation.
    * @return type of the given external relation.
+   * @throws IllegalArgumentException if the relationFieldName is not tracked by the registry
    */
   public String findExternalType(String relationFieldName) {
+    if (!this.externalNameToTypeMap.containsKey(relationFieldName)) {
+      throw new IllegalArgumentException(
+        "external relation with name: " + relationFieldName + " is not tracked by the registry");
+    }
     return this.externalNameToTypeMap.get(relationFieldName);
   }
 

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
@@ -117,6 +117,13 @@ public class DinaMappingRegistry {
     return map;
   }
 
+  /**
+   * Returns a map of external relation field names to their JsonApiExternalRelation.type for a
+   * given class.
+   *
+   * @param resourceClass - a given class with external relations.
+   * @return a map of external relation field names to their JsonApiExternalRelation.type
+   */
   private static Map<String, String> parseExternalRelationNamesToType(Class<?> resourceClass) {
     return FieldUtils.getFieldsListWithAnnotation(resourceClass, JsonApiExternalRelation.class)
       .stream()
@@ -124,6 +131,12 @@ public class DinaMappingRegistry {
         Field::getName, field -> field.getAnnotation(JsonApiExternalRelation.class).type()));
   }
 
+  /**
+   * Returns a set of relations field names which are a Java Collection type.
+   *
+   * @param resourceClass - a given class with relations.
+   * @return a set of relations field names which are a Java Collection type
+   */
   private static Set<String> parseCollectionBasedRelations(Class<?> resourceClass) {
     return FieldUtils.getFieldsListWithAnnotation(resourceClass, JsonApiRelation.class)
       .stream()
@@ -132,6 +145,14 @@ public class DinaMappingRegistry {
       .collect(Collectors.toSet());
   }
 
+  /**
+   * Returns a map of relation field names per class that are not external relations and are
+   * eligible for bean mapping and relation linking to a db backed source. relations that are
+   * collections will be mapped to their collections generic type.
+   *
+   * @param resourceClass - a given class with relations.
+   * @return a map of relation field names per class that are not external relations
+   */
   private static Map<String, Class<?>> parseMappableRelations(Class<?> resourceClass) {
     return FieldUtils.getFieldsListWithAnnotation(resourceClass, JsonApiRelation.class).stream()
       .filter(field -> !field.isAnnotationPresent(JsonApiExternalRelation.class))

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/DinaMappingRegistry.java
@@ -24,12 +24,9 @@ import java.util.stream.Stream;
 
 public class DinaMappingRegistry {
 
-  // Tracks the resource graph for bean mapping
+  // Tracks Attributes per class for bean mapping
   @Getter
-  private final Map<Class<?>, Set<String>> resourceFieldsPerClass;
-  // Tracks the entity graph for bean mapping
-  @Getter
-  private final Map<Class<?>, Set<String>> entityFieldsPerClass;
+  private final Map<Class<?>, Set<String>> attributesPerClass;
   // Tracks the relation types per mappable relation
   @Getter
   private final Map<String, Class<?>> relationTypesPerMappableRelation;
@@ -43,8 +40,7 @@ public class DinaMappingRegistry {
   private final Map<Class<?>, String> jsonIdFieldNamePerClass;
 
   public DinaMappingRegistry(@NonNull Class<?> resourceClass) {
-    this.resourceFieldsPerClass = new HashMap<>();
-    this.entityFieldsPerClass = new HashMap<>();
+    this.attributesPerClass = new HashMap<>();
     this.mappableRelationsPerClass = new HashMap<>();
     this.relationTypesPerMappableRelation = parseRelationTypesPerRelation(resourceClass);
     this.collectionBasedRelationsPerClass = new HashMap<>();
@@ -179,8 +175,8 @@ public class DinaMappingRegistry {
                    !DinaMappingRegistry.isNotMappable(f))
       .map(Field::getName)
       .collect(Collectors.toSet());
-    this.resourceFieldsPerClass.put(cls, fieldsToInclude);
-    this.entityFieldsPerClass.put(entityType, fieldsToInclude);
+    this.attributesPerClass.put(cls, fieldsToInclude);
+    this.attributesPerClass.put(entityType, fieldsToInclude);
   }
 
   private void trackMappableRelations(Class<?> cls, Class<?> entityType, List<Field> relations) {

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/repository/DinaRepository.java
@@ -1,10 +1,9 @@
 package ca.gc.aafc.dina.repository;
 
-import ca.gc.aafc.dina.dto.RelatedEntity;
 import ca.gc.aafc.dina.entity.DinaEntity;
 import ca.gc.aafc.dina.filter.DinaFilterResolver;
-import ca.gc.aafc.dina.mapper.DerivedDtoField;
 import ca.gc.aafc.dina.mapper.DinaMapper;
+import ca.gc.aafc.dina.mapper.DinaMappingLayer;
 import ca.gc.aafc.dina.repository.external.ExternalResourceProvider;
 import ca.gc.aafc.dina.repository.meta.DinaMetaInfo;
 import ca.gc.aafc.dina.repository.meta.JsonApiExternalRelation;
@@ -20,7 +19,6 @@ import io.crnk.core.queryspec.IncludeRelationSpec;
 import io.crnk.core.queryspec.QuerySpec;
 import io.crnk.core.repository.MetaRepository;
 import io.crnk.core.repository.ResourceRepository;
-import io.crnk.core.resource.annotations.JsonApiRelation;
 import io.crnk.core.resource.list.DefaultResourceList;
 import io.crnk.core.resource.list.ResourceList;
 import io.crnk.core.resource.meta.DefaultPagedMetaInformation;
@@ -30,28 +28,16 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.SneakyThrows;
-import org.apache.commons.lang3.reflect.FieldUtils;
 
 import javax.inject.Inject;
 import javax.transaction.Transactional;
 import java.io.Serializable;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * JSONAPI repository that interfaces using DTOs, and uses JPA entities internally. Sparse fields
@@ -75,11 +61,9 @@ public class DinaRepository<D, E extends DinaEntity>
   private final Optional<DinaAuthorizationService> authorizationService;
   private final Optional<AuditService> auditService;
 
-  private final DinaMapper<D, E> dinaMapper;
+  private final DinaMappingLayer<D, E> mappingLayer;
   private final DinaFilterResolver filterResolver;
 
-  private final Map<Class<?>, Set<String>> resourceFieldsPerClass;
-  private final Map<Class<?>, Set<String>> entityFieldsPerClass;
   private final Map<String, String> externalMetaMap;
 
   private static final long DEFAULT_LIMIT = 100;
@@ -102,19 +86,16 @@ public class DinaRepository<D, E extends DinaEntity>
     this.dinaService = dinaService;
     this.authorizationService = authorizationService;
     this.auditService = auditService;
-    this.dinaMapper = dinaMapper;
     this.resourceClass = resourceClass;
     this.entityClass = entityClass;
     this.filterResolver = filterResolver;
-    this.resourceFieldsPerClass =
-      parseFieldsPerClass(resourceClass, new HashMap<>(), DinaRepository::isNotMappable);
-    this.entityFieldsPerClass = getFieldsPerEntity();
     if (externalResourceProvider != null) {
       this.externalMetaMap =
         DinaMetaInfo.parseExternalTypes(resourceClass, externalResourceProvider);
     } else {
       this.externalMetaMap = null;
     }
+    this.mappingLayer = new DinaMappingLayer<>(resourceClass, dinaService, dinaMapper);
   }
 
   /**
@@ -163,7 +144,10 @@ public class DinaRepository<D, E extends DinaEntity>
   public ResourceList<D> findAll(Collection<Serializable> ids, QuerySpec querySpec) {
     String idName = SelectionHandler.getIdAttribute(resourceClass, resourceRegistry);
 
-    List<D> dList = mapToDto(querySpec, fetchEntities(ids, querySpec, idName));
+    List<D> dList = mappingLayer.mapEntitiesToDto(
+      querySpec,
+      fetchEntities(ids, querySpec, idName),
+      findRelations(resourceClass));
 
     Long resourceCount = dinaService.getResourceCount(
       entityClass,
@@ -180,7 +164,7 @@ public class DinaRepository<D, E extends DinaEntity>
         // Skip eager loading on JsonApiExternalRelation-marked fields:
         Class<?> dtoClass = querySpec.getResourceClass();
         for (String attr : ir.getAttributePath()) {
-          if (hasAnnotation(dtoClass, attr, JsonApiExternalRelation.class)) {
+          if (isExternalRelation(dtoClass, attr)) {
             return false;
           }
           dtoClass = PropertyUtils.getPropertyClass(dtoClass, attr);
@@ -199,26 +183,6 @@ public class DinaRepository<D, E extends DinaEntity>
       Optional.ofNullable(querySpec.getLimit()).orElse(DEFAULT_LIMIT).intValue());
   }
 
-  private List<D> mapToDto(QuerySpec querySpec, List<E> returnedEntities) {
-    Set<String> relationsToMap = Stream.concat(
-      querySpec.getIncludedRelations().stream().map(ir -> ir.getAttributePath().get(0)),
-      FieldUtils.getFieldsListWithAnnotation(resourceClass, JsonApiExternalRelation.class)
-        .stream().map(Field::getName)
-    ).collect(Collectors.toSet());
-
-    List<ResourceField> shallowRelationsToMap = findRelations(resourceClass).stream()
-      .filter(rel -> relationsToMap.stream().noneMatch(rel.getUnderlyingName()::equalsIgnoreCase))
-      .collect(Collectors.toList());
-
-    return returnedEntities.stream()
-      .map(e -> {
-        D dto = dinaMapper.toDto(e, entityFieldsPerClass, relationsToMap);
-        mapShallowRelations(e, dto, shallowRelationsToMap);
-        return dto;
-      })
-      .collect(Collectors.toList());
-  }
-
   @Override
   public <S extends D> S save(S resource) {
     Object id = PropertyUtils.getProperty(resource, findIdFieldName(resourceClass));
@@ -231,7 +195,7 @@ public class DinaRepository<D, E extends DinaEntity>
         resourceClass.getSimpleName() + " with ID " + id + " Not Found.");
     }
 
-    mapToEntity(resource, entity, findRelations(resourceClass));
+    mappingLayer.mapToEntity(resource, entity, findRelations(resourceClass));
     dinaService.update(entity);
     auditService.ifPresent(service -> service.audit(resource));
     return resource;
@@ -244,7 +208,7 @@ public class DinaRepository<D, E extends DinaEntity>
     E entity = entityClass.getConstructor().newInstance();
 
     List<ResourceField> relationFields = findRelations(resourceClass);
-    mapToEntity(resource, entity, relationFields);
+    mappingLayer.mapToEntity(resource, entity, relationFields);
 
     authorizationService.ifPresent(auth -> auth.authorizeCreate(entity));
     dinaService.create(entity);
@@ -254,18 +218,6 @@ public class DinaRepository<D, E extends DinaEntity>
       new QuerySpec(resourceClass));
     auditService.ifPresent(service -> service.audit(dto));
     return (S) dto;
-  }
-
-  private <S extends D> void mapToEntity(S dto, E entity, List<ResourceField> relationFields) {
-    Set<String> relationsToMap = relationFields.stream()
-      .map(ResourceField::getUnderlyingName).collect(Collectors.toSet());
-    dinaMapper.applyDtoToEntity(dto, entity, resourceFieldsPerClass, relationsToMap);
-
-    List<ResourceField> relationsToLink = relationFields.stream()
-      .filter(relation ->
-        !hasAnnotation(resourceClass, relation.getUnderlyingName(), JsonApiExternalRelation.class))
-      .collect(Collectors.toList());
-    linkRelations(entity, relationsToLink);
   }
 
   @Override
@@ -278,8 +230,7 @@ public class DinaRepository<D, E extends DinaEntity>
     authorizationService.ifPresent(auth -> auth.authorizeDelete(entity));
     dinaService.delete(entity);
 
-    D dto = dinaMapper.toDto(entity, entityFieldsPerClass, Collections.emptySet());
-    auditService.ifPresent(service -> service.auditDeleteEvent(dto));
+    auditService.ifPresent(service -> service.auditDeleteEvent(mappingLayer.mapForDelete(entity)));
   }
 
   @Override
@@ -302,220 +253,16 @@ public class DinaRepository<D, E extends DinaEntity>
   }
 
   /**
-   * Returns a map of fields per entity class.
-   *
-   * @return a map of fields per entity class.
-   */
-  private Map<Class<?>, Set<String>> getFieldsPerEntity() {
-    return resourceFieldsPerClass.entrySet()
-      .stream()
-      .filter(e -> getRelatedEntity(e.getKey()) != null)
-      .map(e -> new SimpleEntry<>(getRelatedEntity(e.getKey()).value(), e.getValue()))
-      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-  }
-
-  /**
-   * Transverses a given class to return a map of fields per class parsed from the given class. Used
-   * to determine the necessary classes and fields per class when mapping a java bean. Fields marked
-   * with {@link JsonApiRelation} will be treated as separate classes to map and will be transversed
-   * and mapped.
-   *
-   * @param <T>            - Type of class
-   * @param clazz          - Class to parse
-   * @param fieldsPerClass - initial map to use
-   * @param ignoreIf       - predicate to return true for fields to be removed
-   * @return a map of fields per class
-   */
-  @SneakyThrows
-  private static <T> Map<Class<?>, Set<String>> parseFieldsPerClass(
-    @NonNull Class<T> clazz,
-    @NonNull Map<Class<?>, Set<String>> fieldsPerClass,
-    @NonNull Predicate<Field> ignoreIf
-  ) {
-    if (fieldsPerClass.containsKey(clazz)) {
-      return fieldsPerClass;
-    }
-
-    List<Field> relationFields = FieldUtils.getFieldsListWithAnnotation(
-      clazz,
-      JsonApiRelation.class
-    );
-
-    List<Field> attributeFields = FieldUtils.getAllFieldsList(clazz).stream()
-      .filter(f -> !relationFields.contains(f) && !f.isSynthetic() && !ignoreIf.test(f))
-      .collect(Collectors.toList());
-
-    Set<String> fieldsToInclude = attributeFields.stream()
-      .map(Field::getName)
-      .collect(Collectors.toSet());
-
-    fieldsPerClass.put(clazz, fieldsToInclude);
-
-    parseRelations(clazz, fieldsPerClass, relationFields, ignoreIf);
-
-    return fieldsPerClass;
-  }
-
-  /**
-   * Helper method to parse the fields of a given list of relations and add them to a given map.
-   *
-   * @param <T>            - Type of class
-   * @param clazz          - class containing the relations
-   * @param fieldsPerClass - map to add to
-   * @param relationFields - relation fields to transverse
-   */
-  @SneakyThrows
-  private static <T> void parseRelations(
-    Class<T> clazz,
-    Map<Class<?>, Set<String>> fieldsPerClass,
-    List<Field> relationFields,
-    Predicate<Field> removeIf
-  ) {
-    for (Field relationField : relationFields) {
-      if (Collection.class.isAssignableFrom(relationField.getType())) {
-        ParameterizedType genericType = (ParameterizedType) clazz
-          .getDeclaredField(relationField.getName())
-          .getGenericType();
-        for (Type elementType : genericType.getActualTypeArguments()) {
-          parseFieldsPerClass((Class<?>) elementType, fieldsPerClass, removeIf);
-        }
-      } else {
-        parseFieldsPerClass(relationField.getType(), fieldsPerClass, removeIf);
-      }
-    }
-  }
-
-  /**
-   * Replaces the given relations of given entity with there JPA entity equivalent. Relations id's
-   * are used to map a relation to its JPA equivalent.
-   *
-   * @param entity    - entity containing the relations
-   * @param relations - list of relations to map
-   */
-  private void linkRelations(@NonNull E entity, @NonNull List<ResourceField> relations) {
-    mapRelations(entity, entity, relations,
-      (resourceField, relation) ->
-        returnPersistedObject(findIdFieldName(resourceField.getElementType()), relation));
-  }
-
-  /**
-   * Maps the given relations from the given entity to a given dto in a shallow form (Id only).
-   *
-   * @param entity         - source of the mapping
-   * @param dto            - target of the mapping
-   * @param relationsToMap - relations to map
-   */
-  private void mapShallowRelations(E entity, D dto, List<ResourceField> relationsToMap) {
-    mapRelations(entity, dto, relationsToMap,
-      (resourceField, relation) -> {
-        Class<?> elementType = resourceField.getElementType();
-        return createShallowDTO(findIdFieldName(elementType), elementType, relation);
-      });
-  }
-
-  /**
-   * Maps the given relations from a given source to a given target with a given mapping function.
-   *
-   * @param source    - source of the mapping
-   * @param target    - target of the mapping
-   * @param relations - relations to map
-   * @param mapper    - mapping function to apply
-   */
-  private void mapRelations(
-    Object source,
-    Object target,
-    List<ResourceField> relations,
-    BiFunction<ResourceField, Object, Object> mapper
-  ) {
-    for (ResourceField relation : relations) {
-      String fieldName = relation.getUnderlyingName();
-      if (relation.isCollection()) {
-        Collection<?> relationValue = (Collection<?>) PropertyUtils.getProperty(source, fieldName);
-        if (relationValue != null) {
-          Collection<?> mappedCollection = relationValue.stream()
-            .map(rel -> mapper.apply(relation, rel))
-            .collect(Collectors.toList());
-          PropertyUtils.setProperty(target, fieldName, mappedCollection);
-        }
-      } else {
-        Object relationValue = PropertyUtils.getProperty(source, fieldName);
-        if (relationValue != null) {
-          Object mappedRelation = mapper.apply(relation, relationValue);
-          PropertyUtils.setProperty(target, fieldName, mappedRelation);
-        }
-      }
-    }
-  }
-
-  /**
-   * Returns the jpa entity representing a given object with an id field of a given id field name.
-   *
-   * @param idFieldName - name of the id field
-   * @param object      - object to map
-   * @return - jpa entity representing a given object
-   */
-  private Object returnPersistedObject(String idFieldName, Object object) {
-    Object relationID = PropertyUtils.getProperty(object, idFieldName);
-    return dinaService.findOneReferenceByNaturalId(object.getClass(), relationID);
-  }
-
-  /**
-   * Returns true if the dina repo should not map the given field. currently that means if the field
-   * is generated (Marked with {@link DerivedDtoField}) or final.
-   *
-   * @param field - field to evaluate
-   * @return - true if the dina repo should not map the given field
-   */
-  private static boolean isNotMappable(Field field) {
-    return hasAnnotation(field.getDeclaringClass(), field.getName(), DerivedDtoField.class)
-           || Modifier.isFinal(field.getModifiers());
-  }
-
-  /**
    * Returns true if the given class has a given field with an annotation of a given type.
    *
-   * @param <T>             - Class type
-   * @param clazz           - class of the field
-   * @param field           - field to check
-   * @param annotationClass - annotation that is present
+   * @param <T>   - Class type
+   * @param clazz - class of the field
+   * @param field - field to check
    * @return true if a dto field is generated and read-only
    */
   @SneakyThrows(NoSuchFieldException.class)
-  private static <T> boolean hasAnnotation(
-    Class<T> clazz,
-    String field,
-    Class<? extends Annotation> annotationClass
-  ) {
-    return clazz.getDeclaredField(field).isAnnotationPresent(annotationClass);
-  }
-
-  /**
-   * Returns a Dto's related entity (Marked with {@link RelatedEntity}) or else null.
-   *
-   * @param <T>   - Class type
-   * @param clazz - Class with a related entity.
-   * @return a Dto's related entity, or else null
-   */
-  private static <T> RelatedEntity getRelatedEntity(Class<T> clazz) {
-    return clazz.getAnnotation(RelatedEntity.class);
-  }
-
-  /**
-   * Maps the given id field name from a given entity to a new instance of a given type.
-   *
-   * @param idFieldName - name of the id field for the mapping
-   * @param type        - type of new instance to return with the mapping
-   * @param entity      - entity with the id to map
-   * @return - a new instance of a given type with a id value mapped from a given entity.
-   */
-  @SneakyThrows
-  private static Object createShallowDTO(String idFieldName, Class<?> type, Object entity) {
-    Object shallowDTO = type.getConstructor().newInstance();
-    PropertyUtils.setProperty(
-      shallowDTO,
-      idFieldName,
-      PropertyUtils.getProperty(entity, idFieldName));
-    return shallowDTO;
+  private static <T> boolean isExternalRelation(Class<T> clazz, String field) {
+    return clazz.getDeclaredField(field).isAnnotationPresent(JsonApiExternalRelation.class);
   }
 
   /**

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/dto/ProjectDTO.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/dto/ProjectDTO.java
@@ -50,29 +50,4 @@ public final class ProjectDTO {
   @JsonApiRelation
   private ExternalRelationDto originalAuthor;
 
-  @CustomFieldResolver(fieldName = "acMetaDataCreator")
-  public static ExternalRelationDto acMetaDataCreatorToDTO(@NonNull Project entity) {
-    return entity.getAcMetaDataCreator() == null ? null : ExternalRelationDto.builder()
-      .type("agent").id(entity.getAcMetaDataCreator().toString())
-      .build();
-  }
-
-  @CustomFieldResolver(fieldName = "acMetaDataCreator")
-  public static UUID acMetaDataCreatorToEntity(@NonNull ProjectDTO dto) {
-    return dto.getAcMetaDataCreator() == null ? null : UUID.fromString(dto.getAcMetaDataCreator()
-      .getId());
-  }
-
-  @CustomFieldResolver(fieldName = "originalAuthor")
-  public static ExternalRelationDto originalAuthorToDTO(@NonNull Project entity) {
-    return entity.getOriginalAuthor() == null ? null : ExternalRelationDto.builder()
-      .type("author").id(entity.getOriginalAuthor().toString())
-      .build();
-  }
-
-  @CustomFieldResolver(fieldName = "originalAuthor")
-  public static UUID originalAuthorToEntity(@NonNull ProjectDTO dto) {
-    return dto.getOriginalAuthor() == null ? null : UUID.fromString(dto.getOriginalAuthor()
-      .getId());
-  }
 }

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/dto/ProjectDTO.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/dto/ProjectDTO.java
@@ -2,7 +2,6 @@ package ca.gc.aafc.dina.dto;
 
 import ca.gc.aafc.dina.entity.ComplexObject;
 import ca.gc.aafc.dina.entity.Project;
-import ca.gc.aafc.dina.mapper.CustomFieldResolver;
 import ca.gc.aafc.dina.repository.meta.JsonApiExternalRelation;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.crnk.core.resource.annotations.JsonApiId;
@@ -12,7 +11,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 import org.javers.core.metamodel.annotation.PropertyName;
 import org.javers.core.metamodel.annotation.TypeName;
 

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/dto/ProjectDTO.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/dto/ProjectDTO.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 import org.javers.core.metamodel.annotation.PropertyName;
 import org.javers.core.metamodel.annotation.TypeName;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -33,6 +34,8 @@ public final class ProjectDTO {
   @PropertyName("id")
   private UUID uuid;
   private String name;
+  private OffsetDateTime createdOn;
+  private String createdBy;
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   private List<ComplexObject> nameTranslations;

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMapperTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMapperTest.java
@@ -164,7 +164,7 @@ public class DinaMapperTest {
 
   @Test
   public void toDto_FromHibernateProxy_FieldsMapped() {
-    /** Mockable abstract class that works as a Hibernate-proxied Student entity. */
+    /* Mockable abstract class that works as a Hibernate-proxied Student entity. */
     abstract class MockStudentProxy extends Student implements HibernateProxy {
       private static final long serialVersionUID = 1L;
     }

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingLayerIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingLayerIT.java
@@ -112,6 +112,29 @@ public class DinaMappingLayerIT {
     Assertions.assertNull(results.get(0).getAcMetaDataCreator());
   }
 
+  @Test
+  void mapToEntity_WhenRelationsNull_NullsMapped() {
+    ProjectDTO dto = ProjectDTO.builder()
+      .uuid(UUID.randomUUID())
+      .createdBy(RandomStringUtils.randomAlphabetic(5))
+      .createdOn(OffsetDateTime.now())
+      .name(RandomStringUtils.randomAlphabetic(5))
+      .build();
+
+    Project result = new Project();
+    mappingLayer.mapToEntity(dto, result);
+
+    // Validate attributes
+    Assertions.assertEquals(dto.getName(), result.getName());
+    Assertions.assertEquals(dto.getUuid(), result.getUuid());
+    Assertions.assertEquals(dto.getCreatedBy(), result.getCreatedBy());
+    Assertions.assertTrue(dto.getCreatedOn().isEqual(result.getCreatedOn()));
+    // Validate Relations Null
+    Assertions.assertNull(result.getAcMetaDataCreator());
+    Assertions.assertNull(result.getOriginalAuthor());
+    Assertions.assertNull(result.getTask());
+  }
+
   private void assertProject(Project entity, ProjectDTO result) {
     // Validate attributes
     Assertions.assertEquals(entity.getName(), result.getName());

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingLayerIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingLayerIT.java
@@ -1,0 +1,97 @@
+package ca.gc.aafc.dina.mapper;
+
+import ca.gc.aafc.dina.ExternalResourceProviderImplementation;
+import ca.gc.aafc.dina.TestDinaBaseApp;
+import ca.gc.aafc.dina.dto.ProjectDTO;
+import ca.gc.aafc.dina.dto.TaskDTO;
+import ca.gc.aafc.dina.entity.Project;
+import ca.gc.aafc.dina.entity.Task;
+import ca.gc.aafc.dina.filter.DinaFilterResolver;
+import ca.gc.aafc.dina.jpa.BaseDAO;
+import ca.gc.aafc.dina.repository.DinaRepository;
+import ca.gc.aafc.dina.repository.external.ExternalResourceProvider;
+import ca.gc.aafc.dina.service.DinaService;
+import io.crnk.core.queryspec.QuerySpec;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Transactional
+@SpringBootTest(classes = TestDinaBaseApp.class)
+public class DinaMappingLayerIT {
+
+  @Inject
+  private DinaService<Project> service;
+
+  private DinaMappingLayer<ProjectDTO, Project> mappingLayer;
+
+  @BeforeEach
+  void setUp() {
+    mappingLayer = new DinaMappingLayer<>(
+      ProjectDTO.class, service, new DinaMapper<>(ProjectDTO.class));
+  }
+
+  @Test
+  void mapEntitiesToDto() {
+    Project entity = Project.builder().name(RandomStringUtils.randomAlphabetic(5)).build();
+
+    QuerySpec querySpec = new QuerySpec(ProjectDTO.class);
+
+    List<ProjectDTO> results = mappingLayer.mapEntitiesToDto(querySpec, Arrays.asList(entity));
+
+    Assertions.assertEquals(entity.getName(),results.get(0).getName());
+  }
+
+  @TestConfiguration
+  @Import(ExternalResourceProviderImplementation.class)
+  static class DinaMappingLayerITITConfig {
+    @Bean
+    public DinaRepository<ProjectDTO, Project> projectRepo(
+      BaseDAO baseDAO,
+      DinaFilterResolver filterResolver,
+      ExternalResourceProvider externalResourceProvider
+    ) {
+      return new DinaRepository<>(
+        new DinaService<>(baseDAO),
+        Optional.empty(),
+        Optional.empty(),
+        new DinaMapper<>(ProjectDTO.class),
+        ProjectDTO.class,
+        Project.class,
+        filterResolver,
+        externalResourceProvider
+      );
+    }
+
+    @Bean
+    public DinaRepository<TaskDTO, Task> taskRepo(
+      BaseDAO baseDAO,
+      DinaFilterResolver filterResolver,
+      ExternalResourceProvider externalResourceProvider
+    ) {
+      return new DinaRepository<>(
+        new DinaService<>(baseDAO),
+        Optional.empty(),
+        Optional.empty(),
+        new DinaMapper<>(TaskDTO.class),
+        TaskDTO.class,
+        Task.class,
+        filterResolver,
+        externalResourceProvider
+      );
+    }
+  }
+
+}

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingLayerIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingLayerIT.java
@@ -128,12 +128,7 @@ public class DinaMappingLayerIT {
     Project result = new Project();
     mappingLayer.mapToEntity(dto, result);
 
-    // Validate attributes
-    Assertions.assertEquals(dto.getName(), result.getName());
-    Assertions.assertEquals(dto.getUuid(), result.getUuid());
-    Assertions.assertEquals(dto.getCreatedBy(), result.getCreatedBy());
-    Assertions.assertTrue(dto.getCreatedOn().isEqual(result.getCreatedOn()));
-    // Validate Relations Null
+    validateProjectAttributes(dto, result);
     Assertions.assertNull(result.getAcMetaDataCreator());
     Assertions.assertNull(result.getOriginalAuthor());
     Assertions.assertNull(result.getTask());
@@ -150,11 +145,7 @@ public class DinaMappingLayerIT {
     Project result = new Project();
     mappingLayer.mapToEntity(dto, result);
 
-    // Validate attributes
-    Assertions.assertEquals(dto.getName(), result.getName());
-    Assertions.assertEquals(dto.getUuid(), result.getUuid());
-    Assertions.assertEquals(dto.getCreatedBy(), result.getCreatedBy());
-    Assertions.assertTrue(dto.getCreatedOn().isEqual(result.getCreatedOn()));
+    validateProjectAttributes(dto, result);
     // Validate External Relation
     Assertions.assertEquals(
       dto.getAcMetaDataCreator().getId(), result.getAcMetaDataCreator().toString());
@@ -164,6 +155,13 @@ public class DinaMappingLayerIT {
     Assertions.assertEquals(persistedTask.getUuid(), result.getTask().getUuid());
     Assertions.assertEquals(persistedTask.getPowerLevel(), result.getTask().getPowerLevel(),
       "Internal Relation should of been linked");
+  }
+
+  private static void validateProjectAttributes(ProjectDTO dto, Project result) {
+    Assertions.assertEquals(dto.getName(), result.getName());
+    Assertions.assertEquals(dto.getUuid(), result.getUuid());
+    Assertions.assertEquals(dto.getCreatedBy(), result.getCreatedBy());
+    Assertions.assertTrue(dto.getCreatedOn().isEqual(result.getCreatedOn()));
   }
 
   private void assertProject(Project entity, ProjectDTO result) {

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingLayerIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingLayerIT.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import javax.transaction.Transactional;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -49,13 +50,22 @@ public class DinaMappingLayerIT {
     Project entity1 = newProject();
     Project entity2 = newProject();
 
-    QuerySpec querySpec = new QuerySpec(ProjectDTO.class);
     List<ProjectDTO> results = mappingLayer.mapEntitiesToDto(
-      querySpec,
-      Arrays.asList(entity1, entity2));
+      new QuerySpec(ProjectDTO.class), Arrays.asList(entity1, entity2));
 
     assertProject(entity1, results.get(0));
     assertProject(entity2, results.get(1));
+  }
+
+  @Test
+  void mapEntitiesToDto_WhenExternalRelationNull_NullMapped() {
+    Project entity1 = newProject();
+    entity1.setAcMetaDataCreator(null);
+
+    List<ProjectDTO> results = mappingLayer.mapEntitiesToDto(
+      new QuerySpec(ProjectDTO.class), Collections.singletonList(entity1));
+
+    Assertions.assertNull(results.get(0).getAcMetaDataCreator());
   }
 
   private void assertProject(Project entity, ProjectDTO result) {

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingLayerIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingLayerIT.java
@@ -58,6 +58,21 @@ public class DinaMappingLayerIT {
   }
 
   @Test
+  void mapEntitiesToDto_WhenNoRelationsIncluded_ShallowIdsMapped() {
+    Task expectedTask = Task.builder().uuid(UUID.randomUUID()).build();
+
+    Project entity1 = newProject();
+    entity1.setTask(expectedTask);
+    Project entity2 = newProject();
+
+    List<ProjectDTO> results = mappingLayer.mapEntitiesToDto(
+      new QuerySpec(ProjectDTO.class), Arrays.asList(entity1, entity2));
+
+    Assertions.assertEquals(expectedTask.getUuid(), results.get(0).getTask().getUuid());
+    Assertions.assertNull(results.get(1).getTask());
+  }
+
+  @Test
   void mapEntitiesToDto_WhenExternalRelationNull_NullMapped() {
     Project entity1 = newProject();
     entity1.setAcMetaDataCreator(null);
@@ -76,11 +91,9 @@ public class DinaMappingLayerIT {
     Assertions.assertTrue(entity.getCreatedOn().isEqual(result.getCreatedOn()));
     // Validate External Relation
     Assertions.assertEquals(
-      entity.getAcMetaDataCreator().toString(),
-      result.getAcMetaDataCreator().getId());
+      entity.getAcMetaDataCreator().toString(), result.getAcMetaDataCreator().getId());
     Assertions.assertEquals(
-      entity.getOriginalAuthor().toString(),
-      result.getOriginalAuthor().getId());
+      entity.getOriginalAuthor().toString(), result.getOriginalAuthor().getId());
   }
 
   private Project newProject() {

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingRegistryTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingRegistryTest.java
@@ -26,6 +26,23 @@ public class DinaMappingRegistryTest {
   }
 
   @Test
+  void findMappableRelationsForClass() {
+    DinaMappingRegistry registry = new DinaMappingRegistry(PersonDTO.class);
+    MatcherAssert.assertThat(
+      registry.findMappableRelationsForClass(PersonDTO.class),
+      Matchers.containsInAnyOrder("department", "departments"));
+    MatcherAssert.assertThat(
+      registry.findMappableRelationsForClass(Person.class),
+      Matchers.containsInAnyOrder("department", "departments"));
+    MatcherAssert.assertThat(
+      registry.findMappableRelationsForClass(DepartmentDto.class),
+      Matchers.containsInAnyOrder("employees"));
+    MatcherAssert.assertThat(
+      registry.findMappableRelationsForClass(Department.class),
+      Matchers.containsInAnyOrder("employees"));
+  }
+
+  @Test
   void isRelationCollection() {
     DinaMappingRegistry registry = new DinaMappingRegistry(PersonDTO.class);
     Assertions.assertTrue(registry.isRelationCollection(PersonDTO.class, "departments"));

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingRegistryTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingRegistryTest.java
@@ -24,8 +24,8 @@ public class DinaMappingRegistryTest {
   @Test
   void isCollection() {
     DinaMappingRegistry registry = new DinaMappingRegistry(PersonDTO.class);
-    Assertions.assertTrue(registry.isCollection("departments"));
-    Assertions.assertFalse(registry.isCollection("department"));
+    Assertions.assertTrue(registry.isRelationCollection("departments"));
+    Assertions.assertFalse(registry.isRelationCollection("department"));
   }
 
   @Test

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingRegistryTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingRegistryTest.java
@@ -1,9 +1,13 @@
 package ca.gc.aafc.dina.mapper;
 
+import ca.gc.aafc.dina.dto.DepartmentDto;
 import ca.gc.aafc.dina.dto.ExternalRelationDto;
 import ca.gc.aafc.dina.dto.PersonDTO;
 import ca.gc.aafc.dina.dto.ProjectDTO;
 import ca.gc.aafc.dina.dto.TaskDTO;
+import ca.gc.aafc.dina.entity.ComplexObject;
+import ca.gc.aafc.dina.entity.Department;
+import ca.gc.aafc.dina.entity.Person;
 import ca.gc.aafc.dina.entity.Task;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -22,10 +26,14 @@ public class DinaMappingRegistryTest {
   }
 
   @Test
-  void isCollection() {
+  void isRelationCollection() {
     DinaMappingRegistry registry = new DinaMappingRegistry(PersonDTO.class);
-    Assertions.assertTrue(registry.isRelationCollection("departments"));
-    Assertions.assertFalse(registry.isRelationCollection("department"));
+    Assertions.assertTrue(registry.isRelationCollection(PersonDTO.class, "departments"));
+    Assertions.assertTrue(registry.isRelationCollection(Person.class, "departments"));
+    Assertions.assertTrue(registry.isRelationCollection(DepartmentDto.class, "employees"));
+    Assertions.assertTrue(registry.isRelationCollection(Department.class, "employees"));
+    Assertions.assertFalse(registry.isRelationCollection(PersonDTO.class, "department"));
+    Assertions.assertFalse(registry.isRelationCollection(Person.class, "department"));
   }
 
   @Test
@@ -49,5 +57,13 @@ public class DinaMappingRegistryTest {
     MatcherAssert.assertThat(
       registry.getExternalRelations(),
       Matchers.containsInAnyOrder("acMetaDataCreator", "originalAuthor"));
+  }
+
+  @Test
+  void getResolvedType() {
+    ProjectDTO dto = ProjectDTO.builder().build();
+    Assertions.assertEquals(
+      ComplexObject.class, DinaMappingRegistry.getResolvedType(dto, "nameTranslations"));
+    Assertions.assertEquals(TaskDTO.class, DinaMappingRegistry.getResolvedType(dto, "task"));
   }
 }

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingRegistryTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingRegistryTest.java
@@ -24,7 +24,8 @@ public class DinaMappingRegistryTest {
     Assertions.assertEquals("uuid", registry.findJsonIdFieldName(ProjectDTO.class));
     Assertions.assertEquals("uuid", registry.findJsonIdFieldName(TaskDTO.class));
     Assertions.assertEquals("id", registry.findJsonIdFieldName(ExternalRelationDto.class));
-    Assertions.assertNull(registry.findJsonIdFieldName(Task.class));
+    Assertions.assertThrows(
+      IllegalArgumentException.class, () -> registry.findJsonIdFieldName(Task.class));
   }
 
   @Test

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingRegistryTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMappingRegistryTest.java
@@ -1,0 +1,53 @@
+package ca.gc.aafc.dina.mapper;
+
+import ca.gc.aafc.dina.dto.ExternalRelationDto;
+import ca.gc.aafc.dina.dto.PersonDTO;
+import ca.gc.aafc.dina.dto.ProjectDTO;
+import ca.gc.aafc.dina.dto.TaskDTO;
+import ca.gc.aafc.dina.entity.Task;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DinaMappingRegistryTest {
+
+  @Test
+  void findJsonIdFieldName() {
+    DinaMappingRegistry registry = new DinaMappingRegistry(ProjectDTO.class);
+    Assertions.assertEquals("uuid", registry.findJsonIdFieldName(ProjectDTO.class));
+    Assertions.assertEquals("uuid", registry.findJsonIdFieldName(TaskDTO.class));
+    Assertions.assertEquals("id", registry.findJsonIdFieldName(ExternalRelationDto.class));
+    Assertions.assertNull(registry.findJsonIdFieldName(Task.class));
+  }
+
+  @Test
+  void isCollection() {
+    DinaMappingRegistry registry = new DinaMappingRegistry(PersonDTO.class);
+    Assertions.assertTrue(registry.isCollection("departments"));
+    Assertions.assertFalse(registry.isCollection("department"));
+  }
+
+  @Test
+  void isRelationExternal() {
+    DinaMappingRegistry registry = new DinaMappingRegistry(ProjectDTO.class);
+    Assertions.assertTrue(registry.isRelationExternal("acMetaDataCreator"));
+    Assertions.assertTrue(registry.isRelationExternal("originalAuthor"));
+    Assertions.assertFalse(registry.isRelationExternal("task"));
+  }
+
+  @Test
+  void findExternalType() {
+    DinaMappingRegistry registry = new DinaMappingRegistry(ProjectDTO.class);
+    Assertions.assertEquals("agent", registry.findExternalType("acMetaDataCreator"));
+    Assertions.assertEquals("author", registry.findExternalType("originalAuthor"));
+  }
+
+  @Test
+  void getExternalRelations() {
+    DinaMappingRegistry registry = new DinaMappingRegistry(ProjectDTO.class);
+    MatcherAssert.assertThat(
+      registry.getExternalRelations(),
+      Matchers.containsInAnyOrder("acMetaDataCreator", "originalAuthor"));
+  }
+}


### PR DESCRIPTION
External relations no longer require custom field resolvers

Improves mapping layer and increases test coverage for mapping layer responsibilities

- shallow ids
- linking relations to database resources
- mapping external relations

Tested down stream through the object store api