### PR TITLE
20819 method on custom field resolver

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/CustomFieldHandler.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/CustomFieldHandler.java
@@ -1,174 +1,77 @@
 package ca.gc.aafc.dina.mapper;
 
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.lang3.reflect.MethodUtils;
-
-import lombok.NonNull;
-import lombok.SneakyThrows;
+import java.util.stream.Collectors;
 
 /**
  * <p>
- * Handles Custom field resolvers for mapping values between DTOs and Entities.
- * Custom field resolvers are assumed to be declared inside the DTO class.
+ * Handles Custom field resolvers for mapping values between DTOs and Entities. Custom field
+ * resolvers are assumed to be declared inside the DTO class.
  * <p>
  * <p>
- * Field resolvers must have at least one parameter of type entity or Dto. A
- * Field Resolver which accepts a parameter of Entity type would map to the
- * associated field in the DTO and vise versa.
+ * Field resolvers must have at least one parameter of type entity or Dto. A Field Resolver which
+ * accepts a parameter of Entity type would map to the associated field in the DTO and vise versa.
  * <p>
- * 
+ *
  * <p>
  * Field resolver return types must also match the mapping target field type.
  * <p>
  *
- * @param <D>
- *              - Dto type
- * @param <E>
- *              - Entity Type
+ * @param <D> - Dto type
+ * @param <E> - Entity Type
  */
 public class CustomFieldHandler<D, E> {
 
   private final Class<D> dtoClass;
   private final Class<E> entityClass;
 
-  private final Object resolverHolder;
+  private final Map<String, Method> dtoResolvers;
+  private final Map<String, Method> entityResolvers;
 
-  private final Map<String, Method> dtoResolvers = new HashMap<>();
-  private final Map<String, Method> entityResolvers = new HashMap<>();
-
-  public CustomFieldHandler(Class<D> dtoClass, Class<E> entityClass) {
-    this(
-      dtoClass,
-      entityClass,
-      MethodUtils.getMethodsListWithAnnotation(dtoClass, CustomFieldResolver.class));
-  }
-
-  @SneakyThrows
   public CustomFieldHandler(
     @NonNull Class<D> dtoClass,
-    @NonNull Class<E> entityClass,
-    @NonNull List<Method> resolvers
+    @NonNull Class<E> entityClass
   ) {
     this.dtoClass = dtoClass;
     this.entityClass = entityClass;
-    this.resolverHolder = dtoClass.newInstance();
-    initResolvers(resolvers);
+    this.dtoResolvers = initResolvers(dtoClass , entityClass);
+    this.entityResolvers = initResolvers(entityClass, dtoClass);
   }
 
-  /**
-   * <p>
-   * Scans the dto class and adds the custom field resolvers to the appropriate
-   * resolver maps.
-   * <p>
-   * 
-   * @throws IllegalStateException
-   *                                 if the custom field resolver has incorrect
-   *                                 parameters or return types.
-   */
-  private void initResolvers(List<Method> methods) {
-    for (Method method : methods) {
-      validateResolverParameter(method);
-      mapResolverToMap(method);
-    }
-    validateResolverReturnType(dtoClass, dtoResolvers);
-    validateResolverReturnType(entityClass, entityResolvers);
+  private Map<String, Method> initResolvers(Class<?> targetClass,  Class<?> source) {
+    return Arrays
+      .stream(FieldUtils.getFieldsWithAnnotation(targetClass, CustomFieldResolver.class))
+      .collect(Collectors.toMap(Field::getName, f -> getDeclaredMethod(f,source)));
   }
 
-  /**
-   * Adds the custom field resolvers to the appropriate resolver maps.
-   * 
-   * @param resolver
-   */
-  private void mapResolverToMap(Method resolver) {
-    Class<?> methodParamType = resolver.getParameterTypes()[0];
-    CustomFieldResolver customFieldResolver = resolver.getAnnotation(CustomFieldResolver.class);
-
-    if (methodParamType.equals(entityClass)) {
-      dtoResolvers.put(customFieldResolver.setterMethod(), resolver);
-    } else if (methodParamType.equals(dtoClass)) {
-      entityResolvers.put(customFieldResolver.setterMethod(), resolver);
-    } else {
-      throwInvalidParameterResponse(resolver.getName());
-    }
-  }
-
-  /**
-   * Throws IllegalStateException if Field resolvers does not have one parameter
-   * of type entity or Dto
-   * 
-   * @param resolver
-   *                   - resolver to validate
-   */
-  private void validateResolverParameter(Method resolver) {
-    boolean isInvalid = resolver.getParameterCount() != 1 
-      || (!resolver.getParameterTypes()[0].equals(entityClass)
-      && !resolver.getParameterTypes()[0].equals(dtoClass));
-
-    if (isInvalid) {
-      throwInvalidParameterResponse(resolver.getName());
-    }
-  }
-
-  /**
-   * Throws a new IllegalStateException with error message for an inccorect
-   * resolver parameter type.
-   * 
-   * @param methodName
-   *                     - method name for message.
-   */
-  private void throwInvalidParameterResponse(String methodName) {
-    throw new IllegalStateException("Custom field resolver " + methodName
-        + " should accept one parameter of type entity or dto");
-  }
-
-  /**
-   * Validates the given resolvers have return types matching the fields for the
-   * given class.
-   * 
-   * @param <T>
-   *                    - Class type
-   * @param claz
-   *                    - Given class to compare
-   * @param resolvers
-   *                    - resolvers to validate
-   * @throws IllegalStateException
-   *                                 - if the custom field resolver has return
-   *                                 types.
-   */
   @SneakyThrows
-  private static <T> void validateResolverReturnType(Class<T> claz, Map<String, Method> resolvers) {
-    for (Entry<String, Method> entry : resolvers.entrySet()) {
-      Class<?> fieldType = claz.getDeclaredField(entry.getKey()).getType();
-      Class<?> methodReturnType = entry.getValue().getReturnType();
-
-      if (!fieldType.equals(methodReturnType)) {
-        throw new IllegalStateException(
-            "Custom field resolver " + entry.getValue().getName() + " expected return type "
-                + fieldType.getName() + " but was " + methodReturnType.getName());
-      }
-    }
+  private Method getDeclaredMethod(Field field, Class<?> source) {
+    return field.getDeclaringClass()
+      .getDeclaredMethod(
+        field.getAnnotation(CustomFieldResolver.class).setterMethod(),
+        source
+        );
   }
 
   /**
    * Resolve the given selected custom fields from source to target.
-   * 
-   * @param <T>
-   *                         - source Type
-   * @param <S>
-   *                         - target Type
-   * @param selectedFields
-   *                         - fields to resolve
-   * @param source
-   *                         - source bean
-   * @param target
-   *                         - target bean
+   *
+   * @param <T>            - source Type
+   * @param <S>            - target Type
+   * @param selectedFields - fields to resolve
+   * @param source         - source bean
+   * @param target         - target bean
    */
   public <T, S> void resolveFields(Set<String> selectedFields, T source, S target) {
     Map<String, Method> selectedResolvers = getSelectedResolvers(source);
@@ -177,13 +80,10 @@ public class CustomFieldHandler<D, E> {
   }
 
   /**
-   * Returns a copy of the appropriate custom field resolvers for the given
-   * source.
-   * 
-   * @param <T>
-   *                 - source object type
-   * @param source
-   *                 - source object for the mapping
+   * Returns a copy of the appropriate custom field resolvers for the given source.
+   *
+   * @param <T>    - source object type
+   * @param source - source object for the mapping
    * @return - a copy of the appropriate custom field resolvers
    */
   private <T> Map<String, Method> getSelectedResolvers(T source) {
@@ -200,21 +100,16 @@ public class CustomFieldHandler<D, E> {
   /**
    * Maps the custom field resolvers of a given source to a given target.
    *
-   * @param <T>
-   *                       - Type of target
-   * @param <S>
-   *                       - Type of source
-   * @param source
-   *                       - source of the mapping
-   * @param target
-   *                       - target of the mapping
-   * @param resolvers
-   *                       - custom resolvers to apply
+   * @param <T>       - Type of target
+   * @param <S>       - Type of source
+   * @param source    - source of the mapping
+   * @param target    - target of the mapping
+   * @param resolvers - custom resolvers to apply
    */
   @SneakyThrows
   private <T, S> void mapCustomFieldsToTarget(S source, T target, Map<String, Method> resolvers) {
     for (Entry<String, Method> entry : resolvers.entrySet()) {
-      Object mappedValue = entry.getValue().invoke(resolverHolder, source);
+      Object mappedValue = entry.getValue().invoke(target, source);
       PropertyUtils.setProperty(target, entry.getKey(), mappedValue);
     }
   }
@@ -222,13 +117,11 @@ public class CustomFieldHandler<D, E> {
   /**
    * Returns true if the given field name has a custom resolver
    *
-   * @param fieldName
-   *                    - field name of field to check
+   * @param fieldName - field name of field to check
    * @return - true if the given field has custom resolvers.
    */
   public boolean hasCustomFieldResolver(String fieldName) {
-    return dtoResolvers.keySet().contains(fieldName)
-        || entityResolvers.keySet().contains(fieldName);
+    return dtoResolvers.containsKey(fieldName) || entityResolvers.containsKey(fieldName);
   }
 
 }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/CustomFieldHandler.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/CustomFieldHandler.java
@@ -54,7 +54,7 @@ public class CustomFieldHandler<D, E> {
       .collect(Collectors.toMap(Field::getName, f -> parseCustomFieldResolver(f, source)));
   }
 
-  private Method parseCustomFieldResolver(Field field, Class<?> paramType) {
+  private static Method parseCustomFieldResolver(Field field, Class<?> paramType) {
     CustomFieldResolver cfr = field.getAnnotation(CustomFieldResolver.class);
     if (cfr == null) {
       throw new IllegalArgumentException("The given field does not contain a custom field resolver");
@@ -73,7 +73,7 @@ public class CustomFieldHandler<D, E> {
     }
   }
 
-  private void validateResolverReturnType(String name, Class<?> expected, Class<?> actual) {
+  private static void validateResolverReturnType(String name, Class<?> expected, Class<?> actual) {
     if (actual != expected) {
       throw new IllegalArgumentException(
         "Custom field resolver " + name + " should return a type of: " + expected.getSimpleName());
@@ -123,7 +123,7 @@ public class CustomFieldHandler<D, E> {
    * @param resolvers - custom resolvers to apply
    */
   @SneakyThrows
-  private <T, S> void mapCustomFieldsToTarget(S source, T target, Map<String, Method> resolvers) {
+  private static <T, S> void mapCustomFieldsToTarget(S source, T target, Map<String, Method> resolvers) {
     for (Entry<String, Method> entry : resolvers.entrySet()) {
       Object mappedValue = entry.getValue().invoke(target, source);
       PropertyUtils.setProperty(target, entry.getKey(), mappedValue);

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/CustomFieldHandler.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/CustomFieldHandler.java
@@ -91,9 +91,9 @@ public class CustomFieldHandler<D, E> {
     CustomFieldResolver customFieldResolver = resolver.getAnnotation(CustomFieldResolver.class);
 
     if (methodParamType.equals(entityClass)) {
-      dtoResolvers.put(customFieldResolver.fieldName(), resolver);
+      dtoResolvers.put(customFieldResolver.setterMethod(), resolver);
     } else if (methodParamType.equals(dtoClass)) {
-      entityResolvers.put(customFieldResolver.fieldName(), resolver);
+      entityResolvers.put(customFieldResolver.setterMethod(), resolver);
     } else {
       throwInvalidParameterResponse(resolver.getName());
     }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/CustomFieldResolver.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/CustomFieldResolver.java
@@ -5,10 +5,24 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Marks a field to be resolved using a custom field mapping indicated by the annotations given
+ * custom setter method. The setter method refers to the method will set the apply the custom
+ * mapping. A field resolver should always have a parameter type that matches the source class of
+ * the mapping. A field resolver return types must also match the mapping target field type.
+ */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CustomFieldResolver {
 
+  /**
+   * Name of the method that will apply the custom field mapping. A field resolver should always
+   * have a parameter type that matches the source class of the mapping. A field resolver return
+   * types must also match the mapping target field type.
+   *
+   * @return Name of the setter method.
+   */
   String setterMethod();
 
 }
+

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/CustomFieldResolver.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/mapper/CustomFieldResolver.java
@@ -5,20 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Marks a method is used to resolve a custom field mapping. On a class to be
- * used by dina mapper where fieldName refers to a field on the class where the
- * annotation is used.
- */
-@Target(ElementType.METHOD)
+@Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CustomFieldResolver {
 
-  /**
-   * Field Name of the field the custom field resolver will map. Case sensitive.
-   * 
-   * @return Field Name of the field
-   */
-  String fieldName();
+  String setterMethod();
 
 }

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMapperTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMapperTest.java
@@ -342,27 +342,6 @@ public class DinaMapperTest {
     assertEquals(dtoToMap.getName(), resultClassmate.getFriend().getName());
   }
 
-  @Test
-  public void mapperInit_IncorrectResolverReturnTypes_ThrowsIllegalState() {
-    assertThrows(
-      IllegalStateException.class,
-      () -> new DinaMapper<>(IncorrectFieldResolversReturnType.class));
-  }
-
-  @Test
-  public void mapperInit_IncorrectResolverParaMeterCount_ThrowsIllegalState() {
-    assertThrows(
-      IllegalStateException.class,
-      () -> new DinaMapper<>(IncorrectFieldResolversParaCount.class));
-  }
-
-  @Test
-  public void mapperInit_IncorrectResolverParaMeterType_ThrowsIllegalState() {
-    assertThrows(
-      IllegalStateException.class,
-      () -> new DinaMapper<>(IncorrectResolversParaType.class));
-  }
-
   private static StudentDto createDTO() {
     NestedResolverRelationDTO relationWithResolver = NestedResolverRelationDTO.builder()
       .name(RandomStringUtils.random(5, true, false))
@@ -441,6 +420,7 @@ public class DinaMapperTest {
     private StudentDto friend;
 
     // Custom Resolved Field to test
+    @CustomFieldResolver(setterMethod = "customFieldToDto")
     private String customField;
 
     // Relation with Custom Resolved Field to test
@@ -455,15 +435,8 @@ public class DinaMapperTest {
     @JsonApiRelation
     private NoRelatedEntityDTO noRelatedEntityDTO;
 
-    @CustomFieldResolver(fieldName = "customField")
     public String customFieldToDto(Student entity) {
       return entity.getCustomField() == null ? "" : entity.getCustomField().getName();
-    }
-
-    @CustomFieldResolver(fieldName = "customField")
-    public ComplexObject customFieldToEntity(StudentDto dto) {
-      return dto.getCustomField() == null ? null
-        : ComplexObject.builder().name(dto.getCustomField()).build();
     }
 
   }
@@ -484,6 +457,7 @@ public class DinaMapperTest {
     private Student friend;
 
     // Custom Resolved Field to test
+    @CustomFieldResolver(setterMethod = "customFieldToEntity")
     private ComplexObject customField;
 
     // Relation with Custom Resolved Field to test
@@ -492,6 +466,11 @@ public class DinaMapperTest {
     // Many to - Relation to test
     private List<Student> classMates;
 
+    public ComplexObject customFieldToEntity(StudentDto dto) {
+      return dto.getCustomField() == null ? null
+        : ComplexObject.builder().name(dto.getCustomField()).build();
+    }
+
   }
 
   @Data
@@ -499,13 +478,20 @@ public class DinaMapperTest {
   @NoArgsConstructor
   @AllArgsConstructor
   public static final class NestedResolverRelation {
+
     // Custom Resolved Field to test
     private ComplexObject name;
 
     /**
      * Regular field but with the a name matching a custom resolved field on the parent
      */
+    @CustomFieldResolver(setterMethod = "nameToEntity")
     private int customField;
+
+    public ComplexObject nameToEntity(NestedResolverRelationDTO dto) {
+      return dto.getName() == null ? null
+        : ComplexObject.builder().name(dto.getName()).build();
+    }
   }
 
   @Data
@@ -514,7 +500,9 @@ public class DinaMapperTest {
   @AllArgsConstructor
   @RelatedEntity(NestedResolverRelation.class)
   public static final class NestedResolverRelationDTO {
+
     // Custom Resolved Field to test
+    @CustomFieldResolver(setterMethod = "nameToDto")
     private String name;
 
     /**
@@ -522,70 +510,10 @@ public class DinaMapperTest {
      */
     private int customField;
 
-    @CustomFieldResolver(fieldName = "name")
     public String nameToDto(NestedResolverRelation entity) {
       return entity.getName() == null ? "" : entity.getName().getName();
     }
 
-    @CustomFieldResolver(fieldName = "name")
-    public ComplexObject nameToEntity(NestedResolverRelationDTO dto) {
-      return dto.getName() == null ? null
-        : ComplexObject.builder().name(dto.getName()).build();
-    }
-  }
-
-  /**
-   * Class used to test invalid custom resolvers.
-   */
-  @Data
-  @Builder
-  @NoArgsConstructor
-  @AllArgsConstructor
-  @RelatedEntity(NestedResolverRelation.class)
-  public static final class IncorrectFieldResolversReturnType {
-
-    private String customField;
-
-    @CustomFieldResolver(fieldName = "customField")
-    public ComplexObject customFieldToDto(Student entity) {
-      return null;
-    }
-  }
-
-  /**
-   * Class used to test invalid custom resolvers.
-   */
-  @Data
-  @Builder
-  @NoArgsConstructor
-  @AllArgsConstructor
-  @RelatedEntity(NestedResolverRelation.class)
-  public static final class IncorrectFieldResolversParaCount {
-
-    private String customField;
-
-    @CustomFieldResolver(fieldName = "customField")
-    public String customFieldToDto(Student entity, StudentDto dto) {
-      return null;
-    }
-  }
-
-  /**
-   * Class used to test invalid custom resolvers.
-   */
-  @Data
-  @Builder
-  @NoArgsConstructor
-  @AllArgsConstructor
-  @RelatedEntity(NestedResolverRelation.class)
-  public static final class IncorrectResolversParaType {
-
-    private String customField;
-
-    @CustomFieldResolver(fieldName = "customField")
-    public String customFieldToDto(String entity) {
-      return null;
-    }
   }
 
   /**

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMapperTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMapperTest.java
@@ -89,12 +89,14 @@ public class DinaMapperTest {
 
     Map<Class<?>, Set<String>> selectedFieldPerClass = Map.of(
       Student.class,
-      Set.of("customField"));
+      Set.of("customField", "oneSidedDto"));
 
     StudentDto dto = mapper.toDto(entity, selectedFieldPerClass, new HashSet<>());
 
     // Entity (ComplexObject.name) DTOs complex object (String)
     assertEquals(entity.getCustomField().getName(), dto.getCustomField());
+    // One sided custom resolver mapping
+    assertEquals(entity.iq, dto.getOneSidedDto());
   }
 
   @Test
@@ -257,12 +259,14 @@ public class DinaMapperTest {
     StudentDto dtoToMap = createDTO();
 
     Map<Class<?>, Set<String>> selectedFieldPerClass = Map.of(
-      StudentDto.class, Set.of("customField"));
+      StudentDto.class, Set.of("customField", "oneSided"));
 
     mapper.applyDtoToEntity(dtoToMap, result, selectedFieldPerClass, new HashSet<>());
 
     // DTOs complex object (String) -> Entity (ComplexObject.name)
     assertEquals(dtoToMap.getCustomField(), result.getCustomField().getName());
+    // One sided custom resolver mapping
+    assertEquals(dtoToMap.getName(), result.getOneSided());
   }
 
   @Test
@@ -423,6 +427,10 @@ public class DinaMapperTest {
     @CustomFieldResolver(setterMethod = "customFieldToDto")
     private String customField;
 
+    // Custom resolved field on one side only
+    @CustomFieldResolver(setterMethod = "oneSidedSetter")
+    private int oneSidedDto;
+
     // Relation with Custom Resolved Field to test
     @JsonApiRelation
     private NestedResolverRelationDTO relationWithResolver;
@@ -437,6 +445,10 @@ public class DinaMapperTest {
 
     public String customFieldToDto(Student entity) {
       return entity.getCustomField() == null ? "" : entity.getCustomField().getName();
+    }
+
+    public int oneSidedSetter(Student entity) {
+      return entity.iq;
     }
 
   }
@@ -460,6 +472,10 @@ public class DinaMapperTest {
     @CustomFieldResolver(setterMethod = "customFieldToEntity")
     private ComplexObject customField;
 
+    // Custom resolved field on one side only
+    @CustomFieldResolver(setterMethod = "oneSidedSetter")
+    private String oneSided;
+
     // Relation with Custom Resolved Field to test
     private NestedResolverRelation relationWithResolver;
 
@@ -469,6 +485,10 @@ public class DinaMapperTest {
     public ComplexObject customFieldToEntity(StudentDto dto) {
       return dto.getCustomField() == null ? null
         : ComplexObject.builder().name(dto.getCustomField()).build();
+    }
+
+    public String oneSidedSetter(StudentDto dto) {
+      return dto.getName();
     }
 
   }

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMapperTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMapperTest.java
@@ -480,12 +480,12 @@ public class DinaMapperTest {
   public static final class NestedResolverRelation {
 
     // Custom Resolved Field to test
+    @CustomFieldResolver(setterMethod = "nameToEntity")
     private ComplexObject name;
 
     /**
      * Regular field but with the a name matching a custom resolved field on the parent
      */
-    @CustomFieldResolver(setterMethod = "nameToEntity")
     private int customField;
 
     public ComplexObject nameToEntity(NestedResolverRelationDTO dto) {

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMapperTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/mapper/DinaMapperTest.java
@@ -346,6 +346,27 @@ public class DinaMapperTest {
     assertEquals(dtoToMap.getName(), resultClassmate.getFriend().getName());
   }
 
+  @Test
+  public void mapperInit_IncorrectResolverReturnTypes_ThrowsIllegalArgumentException() {
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> new DinaMapper<>(ResolverWithBadReturnType.class));
+  }
+
+  @Test
+  public void mapperInit_IncorrectResolverParaMeterType_ThrowsIllegalArgumentException() {
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> new DinaMapper<>(ResolverWithBadParameter.class));
+  }
+
+  @Test
+  public void mapperInit_IncorrectResolverParaMeterCount_ThrowsIllegalArgumentException() {
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> new DinaMapper<>(ResolverWithBadParameterCount.class));
+  }
+
   private static StudentDto createDTO() {
     NestedResolverRelationDTO relationWithResolver = NestedResolverRelationDTO.builder()
       .name(RandomStringUtils.random(5, true, false))
@@ -546,6 +567,54 @@ public class DinaMapperTest {
   public static final class NoRelatedEntityDTO {
 
     private String customField;
+
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @RelatedEntity(NestedResolverRelation.class)
+  public static final class ResolverWithBadReturnType {
+
+    @CustomFieldResolver(setterMethod = "nameToDto")
+    private String name;
+
+    public int nameToDto(NestedResolverRelation entity) {
+      return 0;
+    }
+
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @RelatedEntity(NestedResolverRelation.class)
+  public static final class ResolverWithBadParameter {
+
+    @CustomFieldResolver(setterMethod = "nameToDto")
+    private String name;
+
+    public String nameToDto(int entity) {
+      return "0";
+    }
+
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @RelatedEntity(NestedResolverRelation.class)
+  public static final class ResolverWithBadParameterCount {
+
+    @CustomFieldResolver(setterMethod = "nameToDto")
+    private String name;
+
+    public String nameToDto(NestedResolverRelation entity, NestedResolverRelation dto) {
+      return "0";
+    }
 
   }
 }


### PR DESCRIPTION
Changes custom field resolvers to be declared on the fields that need them as opposed to the methods that will apply them.

general usesage like the following
```
  public static final class NestedResolverRelation {

    // Custom Resolved Field to test
    @CustomFieldResolver(setterMethod = "nameToEntity")
    private ComplexObject name;

    public ComplexObject nameToEntity(NestedResolverRelationDTO dto) {
      ...
    }
  }
```