### PR TITLE
20832 support removal of audit snapshots

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
@@ -1,8 +1,10 @@
 package ca.gc.aafc.dina.service;
 
-import java.util.List;
-import java.util.Optional;
-
+import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.javers.core.Javers;
 import org.javers.core.metamodel.object.CdoSnapshot;
@@ -13,11 +15,8 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Service;
 
-import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -55,6 +54,11 @@ public class AuditService {
   public Long getResouceCount(String author, AuditInstance instance) {
     return AuditService.getResouceCount(this.jdbcTemplate, author, instance);
   }
+
+  public void removeSnapshots(@NonNull AuditInstance instance) {
+    AuditService.removeSnapshots(this.jdbcTemplate, instance, this.javers);
+  }
+
 
   /**
    * Commit a snapshot for a given object, A dina authenticated user will be set
@@ -144,6 +148,14 @@ public class AuditService {
     return jdbc.queryForObject(sql, parameters, Long.class);
   }
 
+  public static void removeSnapshots(
+    @NonNull NamedParameterJdbcTemplate jdbc,
+    @NonNull AuditInstance instance,
+    @NonNull Javers javers
+  ) {
+
+  }
+
   /**
    * Returns the needed SQL String to return a resouce count for a specific author
    * and id. Author and id can be null for un-filtered counts.
@@ -154,13 +166,12 @@ public class AuditService {
    */
   private static String getResouceCountSql(String author, String id) {
     String baseSql = "select count(*) from jv_snapshot s join jv_commit c on s.commit_fk = c.commit_pk where 1=1 %s %s ;";
-    String sql = String.format(
+    return String.format(
       baseSql,
       StringUtils.isNotBlank(author) ? "and c.author = :author" : "",
       StringUtils.isNotBlank(id)
         ? "and global_id_fk = (select global_id_pk from jv_global_id where local_id = :id and type_name = :type)"
         : "");
-    return sql;
   }
 
   @Builder

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
@@ -169,7 +169,7 @@ public class AuditService {
       String commitDelete = "delete from jv_commit where commit_id = :id";
       jdbc.update(commitDelete, idMap);
 
-      String commitPropertiesDelete = "delete from jv_commit_property where commit_fk = :id;";
+      String commitPropertiesDelete = "delete from jv_commit_property where commit_fk = (select commit_pk from jv_commit where commit_id = :id)";
       jdbc.update(commitPropertiesDelete, idMap);
     }
 

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
@@ -7,6 +7,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.javers.core.Javers;
+import org.javers.core.commit.CommitId;
 import org.javers.core.metamodel.object.CdoSnapshot;
 import org.javers.repository.jql.QueryBuilder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -15,7 +16,9 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -32,7 +35,7 @@ public class AuditService {
   /**
    * Returns a list of Audit snapshots filtered by a given instance and author.
    * Author and instance can be null for un-filtered results.
-   * 
+   *
    * @param instance - instance to filter may be null
    * @param author   - author to filter may be null
    * @param limit    - limit of results
@@ -46,7 +49,7 @@ public class AuditService {
   /**
    * Get the total resource count by a given Author and Audit Instance. Author and
    * instance can be null for un-filtered counts.
-   * 
+   *
    * @param author   - author to filter
    * @param instance - instance to filter
    * @return the total resource count
@@ -63,7 +66,7 @@ public class AuditService {
   /**
    * Commit a snapshot for a given object, A dina authenticated user will be set
    * as the commit author. If a user is not present the author will be anonymous.
-   * 
+   *
    * @param obj - domain object state to persist
    */
   public void audit(@NonNull Object obj) {
@@ -78,7 +81,7 @@ public class AuditService {
    * Commit a shallow delete snapshot for a given object, A dina authenticated
    * user will be set as the commit author. If a user is not present the author
    * will be anonymous.
-   * 
+   *
    * @param obj - domain object state to persist
    */
   public void auditDeleteEvent(@NonNull Object obj) {
@@ -93,7 +96,7 @@ public class AuditService {
    * Returns a list of Audit snapshots using a given Javers Facade filtered by a
    * given instance and author. Author and instance can be null for un-filtered
    * results.
-   * 
+   *
    * @param javers   - Facade to query
    * @param instance - instance to filter may be null
    * @param author   - author to filter may be null
@@ -123,7 +126,7 @@ public class AuditService {
   /**
    * Get the total resource count by a given Author and/or Audit Instance. Author
    * and instance can be null for un-filtered counts.
-   * 
+   *
    * @param jdbc     - NamedParameterJdbcTemplate for the query
    * @param author   - author to filter
    * @param instance - instance filter to apply
@@ -153,13 +156,31 @@ public class AuditService {
     @NonNull AuditInstance instance,
     @NonNull Javers javers
   ) {
+    List<CdoSnapshot> snapshots = javers.findSnapshots(
+      QueryBuilder.byInstanceId(instance.getId(), instance.getType()).build());
+    for (CdoSnapshot snap : snapshots) {
+      CommitId commitId = snap.getCommitId();
+      MapSqlParameterSource idMap = new MapSqlParameterSource(Map.of("id", commitId.valueAsNumber()));
 
+      String snapShotDelete = "delete from jv_snapshot where commit_fk = (select commit_pk from jv_commit where commit_id = :id)";
+      jdbc.update(snapShotDelete, idMap);
+
+      String globalDelete = "delete from jv_global_id where local_id = :id and type_name = :type";
+      jdbc.update(globalDelete, new MapSqlParameterSource(
+        Map.of("id", instance.getId(), "type", instance.getType())));
+
+      String commitDelete = "delete from jv_commit where commit_id = :id";
+      jdbc.update(commitDelete, idMap);
+
+      String commitPropertiesDelete = "delete from jv_commit_property where commit_fk = :id;";
+      jdbc.update(commitPropertiesDelete, idMap);
+    }
   }
 
   /**
    * Returns the needed SQL String to return a resouce count for a specific author
    * and id. Author and id can be null for un-filtered counts.
-   * 
+   *
    * @param author - author filter to apply
    * @param id     - id filter to apply
    * @return SQL String to return a resouce count
@@ -186,7 +207,7 @@ public class AuditService {
     /**
      * Returns an Optional AuditInstance from a string representation or empty if the
      * string is blank. Expected string format is {type}/{id}.
-     * 
+     *
      * @param instanceString - string to parse
      * @throws IllegalArgumentException if the string has an invalid format.
      * @return Optional AuditInstance or empty for blank strings

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
@@ -57,6 +57,11 @@ public class AuditService {
     return AuditService.getResouceCount(this.jdbcTemplate, author, instance);
   }
 
+  /**
+   * Removes the snapshots for a given instance.
+   *
+   * @param instance - instance to remove
+   */
   public void removeSnapshots(@NonNull AuditInstance instance) {
     AuditService.removeSnapshots(this.jdbcTemplate, instance, this.javers);
   }
@@ -150,6 +155,13 @@ public class AuditService {
     return jdbc.queryForObject(sql, parameters, Long.class);
   }
 
+  /**
+   * Removes the snapshots for a given instance.
+   *
+   * @param jdbc     - NamedParameterJdbcTemplate for the query
+   * @param instance - instance to remove
+   * @param javers   - Facade to query
+   */
   public static void removeSnapshots(
     @NonNull NamedParameterJdbcTemplate jdbc,
     @NonNull AuditInstance instance,

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
@@ -16,7 +16,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -160,14 +159,12 @@ public class AuditService {
       QueryBuilder.byInstanceId(instance.getId(), instance.getType()).build());
     for (CdoSnapshot snap : snapshots) {
       CommitId commitId = snap.getCommitId();
-      MapSqlParameterSource idMap = new MapSqlParameterSource(Map.of("id", commitId.valueAsNumber()));
+      MapSqlParameterSource idMap = new MapSqlParameterSource(Map.of(
+        "id",
+        commitId.valueAsNumber()));
 
       String snapShotDelete = "delete from jv_snapshot where commit_fk = (select commit_pk from jv_commit where commit_id = :id)";
       jdbc.update(snapShotDelete, idMap);
-
-      String globalDelete = "delete from jv_global_id where local_id = :id and type_name = :type";
-      jdbc.update(globalDelete, new MapSqlParameterSource(
-        Map.of("id", instance.getId(), "type", instance.getType())));
 
       String commitDelete = "delete from jv_commit where commit_id = :id";
       jdbc.update(commitDelete, idMap);
@@ -175,6 +172,10 @@ public class AuditService {
       String commitPropertiesDelete = "delete from jv_commit_property where commit_fk = :id;";
       jdbc.update(commitPropertiesDelete, idMap);
     }
+
+    String globalDelete = "delete from jv_global_id where local_id = :id and type_name = :type";
+    jdbc.update(globalDelete, new MapSqlParameterSource(
+      Map.of("id", instance.getId(), "type", instance.getType())));
   }
 
   /**

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/AuditService.java
@@ -16,6 +16,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -62,6 +63,7 @@ public class AuditService {
    *
    * @param instance - instance to remove
    */
+  @Transactional
   public void removeSnapshots(@NonNull AuditInstance instance) {
     AuditService.removeSnapshots(this.jdbcTemplate, instance, this.javers);
   }

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/service/AuditServiceIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/service/AuditServiceIT.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.javers.core.Javers;
 import org.javers.core.metamodel.object.CdoSnapshot;
@@ -154,7 +155,8 @@ public class AuditServiceIT {
   void removeSnapshots() {
     EmployeeDto dto = createDto();
     serviceUnderTest.audit(dto);
-
+    dto.setName(RandomStringUtils.randomAlphabetic(4));
+    serviceUnderTest.audit(dto);
     CdoSnapshot result = javers.getLatestSnapshot(dto.getId(), EmployeeDto.class).orElse(null);
     assertNotNull(result);
 

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/service/AuditServiceIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/service/AuditServiceIT.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.javers.core.Javers;
 import org.javers.core.metamodel.object.CdoSnapshot;
 import org.javers.core.metamodel.object.SnapshotType;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -147,6 +148,23 @@ public class AuditServiceIT {
     assertNotNull(result);
     assertEquals(SnapshotType.TERMINAL, result.getType());
     assertEquals(DinaUserConfig.AUTH_USER_NAME, result.getCommitMetadata().getAuthor());
+  }
+
+  @Test
+  void removeSnapshots() {
+    EmployeeDto dto = createDto();
+    serviceUnderTest.audit(dto);
+
+    CdoSnapshot result = javers.getLatestSnapshot(dto.getId(), EmployeeDto.class).orElse(null);
+    assertNotNull(result);
+
+    serviceUnderTest.removeSnapshots(AuditInstance.builder()
+      .type(TYPE)
+      .id(Integer.toString(dto.getId()))
+      .build());
+
+    Assertions.assertTrue(javers.getLatestSnapshot(dto.getId(), EmployeeDto.class).isEmpty(),
+      "There should be no more snapshots for this object");
   }
 
   private static EmployeeDto createDto() {


### PR DESCRIPTION
Updates the AuditService to support the removal of audit snap shots from the Javers DB tables.