### PR TITLE
21196 authorized user id reference

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/security/DevUserConfig.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/security/DevUserConfig.java
@@ -21,6 +21,7 @@ public class DevUserConfig {
   public DinaAuthenticatedUser currentUser() {
     return DinaAuthenticatedUser.builder()
       .agentIdentifer("c628fc6f-c9ad-4bb6-a187-81eb7884bdd7")
+      .internalIdentifer("c628fc6f-c9ad-4bb6-a187-81eb7884bdd7")
       .username("dev")
       .rolesPerGroup(Map.of("dev-group", Set.of(DinaRole.STAFF)))
       .build();

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/security/DinaAuthenticatedUser.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/security/DinaAuthenticatedUser.java
@@ -1,32 +1,35 @@
 package ca.gc.aafc.dina.security;
 
+import lombok.Builder;
+import lombok.Getter;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import lombok.Builder;
-import lombok.Getter;
-
 /**
- * Represent an authenticated user in the context of a DINA Module. This class
- * is immutable.
+ * Represent an authenticated user in the context of a DINA Module. This class is immutable.
  */
 @Getter
 public class DinaAuthenticatedUser {
 
+  private final String internalIdentifer;
   private final String agentIdentifer;
   private final String username;
-
   private final Set<String> groups;
-
   private final Map<String, Set<DinaRole>> rolesPerGroup;
 
   @Builder
-  public DinaAuthenticatedUser(String username, String agentIdentifer, Map<String, Set<DinaRole>> rolesPerGroup) {
+  public DinaAuthenticatedUser(
+    String username,
+    String agentIdentifer,
+    String internalIdentifer,
+    Map<String, Set<DinaRole>> rolesPerGroup
+  ) {
+    this.internalIdentifer = internalIdentifer;
     this.username = username;
     this.agentIdentifer = agentIdentifer;
     this.rolesPerGroup = rolesPerGroup == null ? Collections.emptyMap() : rolesPerGroup;
-
     this.groups = this.rolesPerGroup.keySet();
   }
 }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/security/KeycloakAuthConfig.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/security/KeycloakAuthConfig.java
@@ -1,11 +1,6 @@
 package ca.gc.aafc.dina.security;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-
-import javax.inject.Inject;
-
+import lombok.extern.log4j.Log4j2;
 import org.keycloak.adapters.KeycloakConfigResolver;
 import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
@@ -24,7 +19,10 @@ import org.springframework.security.web.authentication.session.RegisterSessionAu
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.web.context.annotation.RequestScope;
 
-import lombok.extern.log4j.Log4j2;
+import javax.inject.Inject;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 @Configuration
 @ConditionalOnProperty(value = "keycloak.enabled", matchIfMissing = true)
@@ -33,6 +31,7 @@ public class KeycloakAuthConfig extends KeycloakWebSecurityConfigurerAdapter {
 
   private static final String AGENT_IDENTIFIER_CLAIM_KEY = "agent-identifier";
   private static final String GROUPS_CLAIM_KEY = "groups";
+  private static final String INTERNAL_IDENTIFIER_CLAIM_KEY = "internal-identifier";
 
   public KeycloakAuthConfig() {
     super();
@@ -81,7 +80,7 @@ public class KeycloakAuthConfig extends KeycloakWebSecurityConfigurerAdapter {
   @RequestScope
   public DinaAuthenticatedUser currentUser() {
     KeycloakAuthenticationToken token = (KeycloakAuthenticationToken) SecurityContextHolder.getContext()
-        .getAuthentication();
+      .getAuthentication();
 
     if (token == null) {
       return null;
@@ -95,6 +94,7 @@ public class KeycloakAuthConfig extends KeycloakWebSecurityConfigurerAdapter {
       .getOtherClaims();
 
     String agentId = (String) otherClaims.get(AGENT_IDENTIFIER_CLAIM_KEY);
+    String internalID = (String) otherClaims.getOrDefault(INTERNAL_IDENTIFIER_CLAIM_KEY, "");
 
     Map<String, Set<DinaRole>> rolesPerGroup = null;
     if (otherClaims.get(GROUPS_CLAIM_KEY) instanceof Collection) {
@@ -105,11 +105,10 @@ public class KeycloakAuthConfig extends KeycloakWebSecurityConfigurerAdapter {
 
     return DinaAuthenticatedUser.builder()
       .agentIdentifer(agentId)
+      .internalIdentifer(internalID)
       .username(username)
       .rolesPerGroup(rolesPerGroup)
       .build();
   }
-
-
 
 }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/security/KeycloakAuthConfig.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/security/KeycloakAuthConfig.java
@@ -6,6 +6,7 @@ import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
 import org.keycloak.adapters.springsecurity.config.KeycloakWebSecurityConfigurerAdapter;
 import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
+import org.keycloak.representations.AccessToken;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -88,13 +89,13 @@ public class KeycloakAuthConfig extends KeycloakWebSecurityConfigurerAdapter {
 
     String username = token.getName();
 
-    Map<String, Object> otherClaims = token.getAccount()
+    AccessToken accessToken = token.getAccount()
       .getKeycloakSecurityContext()
-      .getToken()
-      .getOtherClaims();
+      .getToken();
+    Map<String, Object> otherClaims = accessToken.getOtherClaims();
 
     String agentId = (String) otherClaims.get(AGENT_IDENTIFIER_CLAIM_KEY);
-    String internalID = (String) otherClaims.getOrDefault(INTERNAL_IDENTIFIER_CLAIM_KEY, "");
+    String internalID = accessToken.getSubject();
 
     Map<String, Set<DinaRole>> rolesPerGroup = null;
     if (otherClaims.get(GROUPS_CLAIM_KEY) instanceof Collection) {

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/security/KeycloakAuthConfig.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/security/KeycloakAuthConfig.java
@@ -32,7 +32,6 @@ public class KeycloakAuthConfig extends KeycloakWebSecurityConfigurerAdapter {
 
   private static final String AGENT_IDENTIFIER_CLAIM_KEY = "agent-identifier";
   private static final String GROUPS_CLAIM_KEY = "groups";
-  private static final String INTERNAL_IDENTIFIER_CLAIM_KEY = "internal-identifier";
 
   public KeycloakAuthConfig() {
     super();

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/security/WithMockKeycloakUserIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/security/WithMockKeycloakUserIT.java
@@ -5,6 +5,7 @@ import ca.gc.aafc.dina.dto.PersonDTO;
 import ca.gc.aafc.dina.entity.Person;
 import ca.gc.aafc.dina.repository.DinaRepository;
 import ca.gc.aafc.dina.testsupport.security.WithMockKeycloakUser;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -14,8 +15,8 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest(
-    classes = TestDinaBaseApp.class,
-    properties = "keycloak.enabled: true"
+  classes = TestDinaBaseApp.class,
+  properties = "keycloak.enabled: true"
 )
 public class WithMockKeycloakUserIT {
 
@@ -23,6 +24,8 @@ public class WithMockKeycloakUserIT {
 
   @Inject
   private DinaRepository<PersonDTO, Person> dinaRepository;
+  @Inject
+  private DinaAuthenticatedUser currentUser;
 
   @WithMockKeycloakUser(groupRole = {"group 1:staff", "group 3:staff"})
   @Test
@@ -30,6 +33,16 @@ public class WithMockKeycloakUserIT {
     PersonDTO dto = PersonDTO.builder().uuid(UUID.randomUUID()).group(GROUP_1).name("name").build();
     PersonDTO result = dinaRepository.create(dto);
     assertNotNull(result.getUuid());
+  }
+
+  @WithMockKeycloakUser(
+    agentIdentifier = "agent one",
+    internalIdentifier = "internal",
+    groupRole = {"group 1:staff", "group 3:staff"})
+  @Test
+  public void withMockedUser_UserMocked() {
+    Assertions.assertEquals("internal", currentUser.getInternalIdentifer());
+    Assertions.assertEquals("agent one", currentUser.getAgentIdentifer());
   }
 
 }

--- a/dina-test-support/src/main/java/ca/gc/aafc/dina/testsupport/security/WithMockKeycloakSecurityContextFactory.java
+++ b/dina-test-support/src/main/java/ca/gc/aafc/dina/testsupport/security/WithMockKeycloakSecurityContextFactory.java
@@ -26,7 +26,6 @@ public class WithMockKeycloakSecurityContextFactory
   // In production, keys (and claims) are set by Keycloak
   private static final String GROUPS_CLAIM_KEY = "groups";
   private static final String AGENT_IDENTIFIER_CLAIM_KEY = "agent-identifier";
-  private static final String INTERNAL_IDENTIFIER_CLAIM_KEY = "internal-identifier";
 
   @Override
   public SecurityContext createSecurityContext(WithMockKeycloakUser mockKeycloakUser) {
@@ -44,7 +43,7 @@ public class WithMockKeycloakSecurityContextFactory
       accessToken.setOtherClaims(AGENT_IDENTIFIER_CLAIM_KEY, mockKeycloakUser.agentIdentifier());
     }
     if (StringUtils.isNotBlank(mockKeycloakUser.internalIdentifier())) {
-      accessToken.setOtherClaims(INTERNAL_IDENTIFIER_CLAIM_KEY, mockKeycloakUser.internalIdentifier());
+      accessToken.setSubject(mockKeycloakUser.internalIdentifier());
     }
 
     RefreshableKeycloakSecurityContext ctx = new RefreshableKeycloakSecurityContext(null, null,

--- a/dina-test-support/src/main/java/ca/gc/aafc/dina/testsupport/security/WithMockKeycloakSecurityContextFactory.java
+++ b/dina-test-support/src/main/java/ca/gc/aafc/dina/testsupport/security/WithMockKeycloakSecurityContextFactory.java
@@ -26,6 +26,7 @@ public class WithMockKeycloakSecurityContextFactory
   // In production, keys (and claims) are set by Keycloak
   private static final String GROUPS_CLAIM_KEY = "groups";
   private static final String AGENT_IDENTIFIER_CLAIM_KEY = "agent-identifier";
+  private static final String INTERNAL_IDENTIFIER_CLAIM_KEY = "internal-identifier";
 
   @Override
   public SecurityContext createSecurityContext(WithMockKeycloakUser mockKeycloakUser) {
@@ -41,6 +42,9 @@ public class WithMockKeycloakSecurityContextFactory
 
     if (StringUtils.isNotBlank(mockKeycloakUser.agentIdentifier())) {
       accessToken.setOtherClaims(AGENT_IDENTIFIER_CLAIM_KEY, mockKeycloakUser.agentIdentifier());
+    }
+    if (StringUtils.isNotBlank(mockKeycloakUser.internalIdentifier())) {
+      accessToken.setOtherClaims(INTERNAL_IDENTIFIER_CLAIM_KEY, mockKeycloakUser.internalIdentifier());
     }
 
     RefreshableKeycloakSecurityContext ctx = new RefreshableKeycloakSecurityContext(null, null,

--- a/dina-test-support/src/main/java/ca/gc/aafc/dina/testsupport/security/WithMockKeycloakUser.java
+++ b/dina-test-support/src/main/java/ca/gc/aafc/dina/testsupport/security/WithMockKeycloakUser.java
@@ -16,10 +16,13 @@ public @interface WithMockKeycloakUser {
 
   /**
    * Format {"group:role", "group2:role2"}
+   *
    * @return
    */
   String[] groupRole() default "";
 
   String agentIdentifier() default "";
+
+  String internalIdentifier() default "";
 
 }


### PR DESCRIPTION
Updates the authenticated user to support a new claim in the token. the internal identifier.

The token parsing and mocker user test support has also been updated.