### PR TITLE
20989 add etag support

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/DinaBaseApiAutoConfiguration.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/DinaBaseApiAutoConfiguration.java
@@ -8,6 +8,7 @@ import io.crnk.spring.jpa.SpringTransactionRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -70,6 +71,11 @@ public class DinaBaseApiAutoConfiguration implements WebMvcConfigurer {
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(localeChangeInterceptor());
+  }
+
+  @Bean
+  public ShallowEtagHeaderFilter shallowEtagHeaderFilter() {
+    return new ShallowEtagHeaderFilter();
   }
 
 }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/DinaBaseApiAutoConfiguration.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/DinaBaseApiAutoConfiguration.java
@@ -8,7 +8,6 @@ import io.crnk.spring.jpa.SpringTransactionRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
-import org.springframework.web.filter.ShallowEtagHeaderFilter;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -71,11 +70,6 @@ public class DinaBaseApiAutoConfiguration implements WebMvcConfigurer {
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(localeChangeInterceptor());
-  }
-
-  @Bean
-  public ShallowEtagHeaderFilter shallowEtagHeaderFilter() {
-    return new ShallowEtagHeaderFilter();
   }
 
 }

--- a/docs/etags.adoc
+++ b/docs/etags.adoc
@@ -10,6 +10,19 @@ public ShallowEtagHeaderFilter shallowEtagHeaderFilter() {
 }
 ----
 
+To target specific URL patterns, you instead use a FilterRegistrationBean which allows for additional configurations.
+[source,java]
+----
+@Bean
+public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
+    FilterRegistrationBean<ShallowEtagHeaderFilter> filterRegistrationBean
+      = new FilterRegistrationBean<>( new ShallowEtagHeaderFilter());
+    filterRegistrationBean.addUrlPatterns("/foos/*");
+    filterRegistrationBean.setName("etagFilter");
+    return filterRegistrationBean;
+}
+----
+
 Sending a request with the 'If-None-Match' header will enable the use of the Etags as the following example of a request and response shows.
 
 [source,bash]

--- a/docs/etags.adoc
+++ b/docs/etags.adoc
@@ -1,0 +1,24 @@
+= Etags
+
+Etags can be enabled through the declaration of the ShallowEtagHeaderFilter bean.
+
+[source,java]
+----
+@Bean
+public ShallowEtagHeaderFilter shallowEtagHeaderFilter() {
+    return new ShallowEtagHeaderFilter();
+}
+----
+
+Sending a request with the 'If-None-Match' header will enable the use of the Etags as the following example of a request and response shows.
+
+[source,bash]
+----
+//Request
+curl -H "Accept: application/json" -H 'If-None-Match: "f88dd058fe004909615a64f01be66a7"'
+ -i http://localhost:8080/spring-boot-rest/foos/1
+
+//Response
+ HTTP/1.1 304 Not Modified
+ ETag: "f88dd058fe004909615a64f01be66a7"
+----

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -23,3 +23,5 @@ include::externalTypes.adoc[]
 include::release.adoc[]
 
 include::fieldAdapters.adoc[]
+
+include::etags.adoc[]


### PR DESCRIPTION
adds documentation for etags.

```
curl --request GET \
  --url http://localhost:8081/api/v1/metadata/066736b4-d9d5-4563-9075-de2963ea2c97
```

You can see the etag in the response headers

```
ETag: "099788fd54e81706693cf05038c26b6e6"
Content-Type: application/vnd.api+json;charset=utf-8
Content-Length: 2199
Date: Wed, 30 Dec 2020 16:15:20 GMT
```

Curl the resource with the additional 'if' header

```
curl --request GET \
  --url http://localhost:8081/api/v1/metadata/066736b4-d9d5-4563-9075-de2963ea2c97 \
  --header 'If-None-Match: "099788fd54e81706693cf05038c26b6e6"'
```


You get a 304 response

```
304 Not Modified 0Bytes
ETag: "099788fd54e81706693cf05038c26b6e6"
Date: Wed, 30 Dec 2020 16:16:01 GMT
```

