### PR TITLE
21971 expand dina service for rsql

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
@@ -1,12 +1,12 @@
 package ca.gc.aafc.dina.jpa;
 
-import java.io.Serializable;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
+import ca.gc.aafc.dina.service.DinaService;
+import io.crnk.core.engine.information.bean.BeanInformation;
+import lombok.NonNull;
+import org.hibernate.Session;
+import org.hibernate.SimpleNaturalIdLoadAccess;
+import org.hibernate.annotations.NaturalId;
+import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -22,15 +22,13 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
-
-import ca.gc.aafc.dina.service.DinaService;
-import org.hibernate.Session;
-import org.hibernate.SimpleNaturalIdLoadAccess;
-import org.hibernate.annotations.NaturalId;
-import org.springframework.stereotype.Component;
-
-import io.crnk.core.engine.information.bean.BeanInformation;
-import lombok.NonNull;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Base Data Access Object layer. This class should be the only one holding a
@@ -355,17 +353,13 @@ public class BaseDAO {
    */
   public <E> Long getResourceCount(
     @NonNull Class<E> entityClass,
-    @NonNull Function<DinaService.DinaFilterPackage, Predicate[]> predicateSupplier
+    @NonNull DinaService.DinaPredicateSupplier<E> predicateSupplier
   ) {
     CriteriaBuilder cb = entityManager.getCriteriaBuilder();
     CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
     Root<E> root = countQuery.from(entityClass);
     countQuery.select(cb.count(root));
-    countQuery.where(predicateSupplier.apply(DinaService.DinaFilterPackage.builder()
-      .root(root)
-      .em(createWithEntityManager(manager -> manager))
-      .criteriaBuilder(cb)
-      .build()));
+    countQuery.where(predicateSupplier.supply(cb, root, createWithEntityManager(m -> m)));
     return entityManager.createQuery(countQuery).getSingleResult();
   }
 }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
@@ -1,6 +1,5 @@
 package ca.gc.aafc.dina.jpa;
 
-import ca.gc.aafc.dina.service.DinaService;
 import io.crnk.core.engine.information.bean.BeanInformation;
 import lombok.NonNull;
 import org.hibernate.Session;
@@ -328,7 +327,7 @@ public class BaseDAO {
    */
   public <E> Long getResourceCount(
     @NonNull Class<E> entityClass,
-    @NonNull DinaService.DinaPredicateSupplier<E> predicateSupplier
+    @NonNull PredicateSupplier<E> predicateSupplier
   ) {
     CriteriaBuilder cb = entityManager.getCriteriaBuilder();
     CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
@@ -23,6 +23,7 @@ import javax.persistence.criteria.Root;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 
+import ca.gc.aafc.dina.service.DinaService;
 import org.hibernate.Session;
 import org.hibernate.SimpleNaturalIdLoadAccess;
 import org.hibernate.annotations.NaturalId;
@@ -49,7 +50,7 @@ public class BaseDAO {
 
   /**
    * This method can be used to inject the EntityManager into an external object.
-   * 
+   *
    * @param creator
    */
   public <T> T createWithEntityManager(Function<EntityManager, T> creator) {
@@ -60,7 +61,7 @@ public class BaseDAO {
   /**
    * Utility function that can check if a lazy loaded attribute is actually
    * loaded.
-   * 
+   *
    * @param entity
    * @param fieldName
    * @return
@@ -76,7 +77,7 @@ public class BaseDAO {
   /**
    * Find an entity by it's natural ID or database ID. The method assumes that the
    * naturalId is unique.
-   * 
+   *
    * @param id
    * @param entityClass
    * @return
@@ -88,7 +89,7 @@ public class BaseDAO {
   /**
    * Find an entity by it's {@link NaturalId}. The method assumes that the
    * naturalId is unique.
-   * 
+   *
    * @param id
    * @param entityClass
    * @return
@@ -101,7 +102,7 @@ public class BaseDAO {
   /**
    * Find an entity by a specific property. The method assumes that the property
    * is unique.
-   * 
+   *
    * @param clazz
    * @param property
    * @param value
@@ -188,7 +189,7 @@ public class BaseDAO {
   /**
    * Returns a reference to an entity that should exist without actually loading it. Useful to set
    * relationships without loading the entity.
-   * 
+   *
    * @param entityClass
    * @param naturalId
    * @return
@@ -202,13 +203,13 @@ public class BaseDAO {
   /**
    * Set a relationship by calling the provided {@link Consumer} with a reference Entity loaded by
    * NaturalId. A reference to the entity allows to set a foreign key without loading the other entity.
-   * 
+   *
    * Usage:
-   * 
+   *
    * Using the object 'dep', set the relationship to DepartmentType using only its NaturalId (depTypeUUID).
    * baseDAO.setRelationshipByNaturalIdReference(DepartmentType.class, depTypeUUID,
         (x) -> dep.setDepartmentType(x));
-   * 
+   *
    * @param entityClass entity to link to that will be loaded with a reference entity
    * @param naturalId value
    * @param objConsumer
@@ -219,7 +220,7 @@ public class BaseDAO {
 
   /**
    * Save the provided entity.
-   * 
+   *
    * @param entity
    */
   public void create(Object entity) {
@@ -228,7 +229,7 @@ public class BaseDAO {
 
   /**
    * Merge the state of a given entity into the current persistence context.
-   * 
+   *
    * @param <E>    Type of the entity
    * @param entity entity to update
    * @return returns the managed instance the state was merged to.
@@ -242,7 +243,7 @@ public class BaseDAO {
 
   /**
    * Delete the provided entity.
-   * 
+   *
    * @param entity
    */
   public void delete(Object entity) {
@@ -251,7 +252,7 @@ public class BaseDAO {
 
   /**
    * Same as {@link Validator#validate(Object, Class...)}
-   * 
+   *
    * @param entity
    *          the entity to validate (not null)
    * @return constraint violations or an empty set if none
@@ -262,7 +263,7 @@ public class BaseDAO {
 
   /**
    * Given a class, this method will extract the name of the field annotated with {@link NaturalId}.
-   * 
+   *
    * @param entityClass
    * @return
    */
@@ -279,7 +280,7 @@ public class BaseDAO {
 
   /**
    * Given a class, this method will return the name of the field annotated with {@link Id}.
-   * 
+   *
    * @param entityClass
    * @return
    */
@@ -293,7 +294,7 @@ public class BaseDAO {
   /**
    * returns a {@link CriteriaBuilder} for the creation of {@link CriteriaQuery},
    * {@link Predicate}, {@link Expression}, and compound selections.
-   * 
+   *
    * @return {@link CriteriaBuilder}
    */
   public CriteriaBuilder getCriteriaBuilder() {
@@ -322,7 +323,7 @@ public class BaseDAO {
 
   /**
    * Returns the resource count from a given predicate supplier.
-   * 
+   *
    * @param <E>
    * @param entityClass
    *                            - entity class to query cannot be null
@@ -344,4 +345,27 @@ public class BaseDAO {
     return entityManager.createQuery(countQuery).getSingleResult();
   }
 
+  /**
+   * Returns the resource count from a given predicate supplier.
+   *
+   * @param <E>               entity type
+   * @param entityClass       - entity class to query cannot be null
+   * @param predicateSupplier - function to return the predicates cannot be null
+   * @return resource count
+   */
+  public <E> Long getResourceCount(
+    @NonNull Class<E> entityClass,
+    @NonNull Function<DinaService.DinaFilterPackage, Predicate[]> predicateSupplier
+  ) {
+    CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+    CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+    Root<E> root = countQuery.from(entityClass);
+    countQuery.select(cb.count(root));
+    countQuery.where(predicateSupplier.apply(DinaService.DinaFilterPackage.builder()
+      .root(root)
+      .em(createWithEntityManager(manager -> manager))
+      .criteriaBuilder(cb)
+      .build()));
+    return entityManager.createQuery(countQuery).getSingleResult();
+  }
 }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
@@ -26,7 +26,6 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
@@ -322,30 +322,6 @@ public class BaseDAO {
   /**
    * Returns the resource count from a given predicate supplier.
    *
-   * @param <E>
-   * @param entityClass
-   *                            - entity class to query cannot be null
-   * @param predicateSupplier
-   *                            - function to return the predicates cannot be null
-   * @return resource count
-   */
-  public <E> Long getResourceCount(
-    @NonNull Class<E> entityClass,
-    @NonNull BiFunction<CriteriaBuilder, Root<E>, Predicate[]> predicateSupplier
-  ) {
-    CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-    CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
-    Root<E> root = countQuery.from(entityClass);
-
-    countQuery.select(cb.count(root));
-    countQuery.where(predicateSupplier.apply(cb, root));
-
-    return entityManager.createQuery(countQuery).getSingleResult();
-  }
-
-  /**
-   * Returns the resource count from a given predicate supplier.
-   *
    * @param <E>               entity type
    * @param entityClass       - entity class to query cannot be null
    * @param predicateSupplier - function to return the predicates cannot be null

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
@@ -55,6 +55,19 @@ public class BaseDAO {
   }
 
   /**
+   * Used to call the provided PredicateSupplier with the EntityManager.
+   * @param where
+   * @param criteriaBuilder
+   * @param root
+   * @param <T>
+   * @return
+   */
+  public <T> Predicate[] buildPredicateFromSupplier(PredicateSupplier<T> where, CriteriaBuilder criteriaBuilder, Root<T> root) {
+    return where.supply(criteriaBuilder, root, entityManager);
+  }
+
+
+  /**
    * Utility function that can check if a lazy loaded attribute is actually
    * loaded.
    *
@@ -333,7 +346,7 @@ public class BaseDAO {
     CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
     Root<E> root = countQuery.from(entityClass);
     countQuery.select(cb.count(root));
-    countQuery.where(predicateSupplier.supply(cb, root, createWithEntityManager(m -> m)));
+    countQuery.where(predicateSupplier.supply(cb, root, entityManager));
     return entityManager.createQuery(countQuery).getSingleResult();
   }
 }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/PredicateSupplier.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/PredicateSupplier.java
@@ -1,0 +1,12 @@
+package ca.gc.aafc.dina.jpa;
+
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+@FunctionalInterface
+public
+interface PredicateSupplier<T> {
+  Predicate[] supply(CriteriaBuilder criteriaBuilder, Root<T> root, EntityManager em);
+}

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/PredicateSupplier.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/PredicateSupplier.java
@@ -6,7 +6,6 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 @FunctionalInterface
-public
-interface PredicateSupplier<T> {
+public interface PredicateSupplier<T> {
   Predicate[] supply(CriteriaBuilder criteriaBuilder, Root<T> root, EntityManager em);
 }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DefaultDinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DefaultDinaService.java
@@ -14,7 +14,6 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.util.List;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * Service class for database interactions with a {@link DinaEntity}.
@@ -82,11 +81,8 @@ public class DefaultDinaService<E extends DinaEntity> implements DinaService<E> 
     int startIndex,
     int maxResult
   ) {
-    CriteriaBuilder criteriaBuilder = baseDAO.getCriteriaBuilder();
-    CriteriaQuery<T> criteria = criteriaBuilder.createQuery(entityClass);
-    Root<T> root = criteria.from(entityClass);
-    Predicate[] predicates = where.apply(criteriaBuilder, root);
-    return findAll(root, predicates, criteria, criteriaBuilder, startIndex, maxResult, orderBy);
+    return findAll(entityClass, (criteriaBuilder, root, em) -> where.apply(criteriaBuilder, root),
+      orderBy, startIndex, maxResult);
   }
 
   /**
@@ -102,7 +98,7 @@ public class DefaultDinaService<E extends DinaEntity> implements DinaService<E> 
   @Override
   public <T> List<T> findAll(
     @NonNull Class<T> entityClass,
-    @NonNull Function<DinaFilterPackage, Predicate[]> where,
+    @NonNull DinaService.DinaPredicateSupplier<T> where,
     BiFunction<CriteriaBuilder, Root<T>, List<Order>> orderBy,
     int startIndex,
     int maxResult
@@ -110,23 +106,7 @@ public class DefaultDinaService<E extends DinaEntity> implements DinaService<E> 
     CriteriaBuilder criteriaBuilder = baseDAO.getCriteriaBuilder();
     CriteriaQuery<T> criteria = criteriaBuilder.createQuery(entityClass);
     Root<T> root = criteria.from(entityClass);
-    Predicate[] predicates = where.apply(DinaFilterPackage.builder()
-      .criteriaBuilder(criteriaBuilder)
-      .root(root)
-      .em(baseDAO.createWithEntityManager(manager -> manager))
-      .build());
-    return findAll(root, predicates, criteria, criteriaBuilder, startIndex, maxResult, orderBy);
-  }
-
-  private <T> List<T> findAll(
-    Root<T> root,
-    Predicate[] predicates,
-    CriteriaQuery<T> criteria,
-    CriteriaBuilder criteriaBuilder,
-    int startIndex,
-    int maxResult,
-    BiFunction<CriteriaBuilder, Root<T>, List<Order>> orderBy
-  ) {
+    Predicate[] predicates = where.supply(criteriaBuilder, root, baseDAO.createWithEntityManager(m -> m));
     criteria.where(predicates).select(root);
     if (orderBy != null) {
       criteria.orderBy(orderBy.apply(criteriaBuilder, root));
@@ -144,7 +124,7 @@ public class DefaultDinaService<E extends DinaEntity> implements DinaService<E> 
   @Override
   public <T> Long getResourceCount(
     @NonNull Class<T> entityClass,
-    @NonNull Function<DinaFilterPackage, Predicate[]> predicateSupplier
+    @NonNull DinaService.DinaPredicateSupplier<T> predicateSupplier
   ) {
     return baseDAO.getResourceCount(entityClass, predicateSupplier);
   }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DefaultDinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DefaultDinaService.java
@@ -86,8 +86,7 @@ public class DefaultDinaService<E extends DinaEntity> implements DinaService<E> 
     CriteriaQuery<T> criteria = criteriaBuilder.createQuery(entityClass);
     Root<T> root = criteria.from(entityClass);
     Predicate[] predicates = where.apply(criteriaBuilder, root);
-    applySortAndFilters(orderBy, criteriaBuilder, criteria, root, predicates);
-    return baseDAO.resultListFromCriteria(criteria, startIndex, maxResult);
+    return findAll(root, predicates, criteria, criteriaBuilder, startIndex, maxResult, orderBy);
   }
 
   /**
@@ -116,21 +115,23 @@ public class DefaultDinaService<E extends DinaEntity> implements DinaService<E> 
       .root(root)
       .em(baseDAO.createWithEntityManager(manager -> manager))
       .build());
-    applySortAndFilters(orderBy, criteriaBuilder, criteria, root, predicates);
-    return baseDAO.resultListFromCriteria(criteria, startIndex, maxResult);
+    return findAll(root, predicates, criteria, criteriaBuilder, startIndex, maxResult, orderBy);
   }
 
-  private <T> void applySortAndFilters(
-    BiFunction<CriteriaBuilder, Root<T>, List<Order>> orderBy,
-    CriteriaBuilder criteriaBuilder,
-    CriteriaQuery<T> criteria,
+  private <T> List<T> findAll(
     Root<T> root,
-    Predicate[] predicates
+    Predicate[] predicates,
+    CriteriaQuery<T> criteria,
+    CriteriaBuilder criteriaBuilder,
+    int startIndex,
+    int maxResult,
+    BiFunction<CriteriaBuilder, Root<T>, List<Order>> orderBy
   ) {
     criteria.where(predicates).select(root);
     if (orderBy != null) {
       criteria.orderBy(orderBy.apply(criteriaBuilder, root));
     }
+    return baseDAO.resultListFromCriteria(criteria, startIndex, maxResult);
   }
 
   /**

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DefaultDinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DefaultDinaService.java
@@ -2,6 +2,7 @@ package ca.gc.aafc.dina.service;
 
 import ca.gc.aafc.dina.entity.DinaEntity;
 import ca.gc.aafc.dina.jpa.BaseDAO;
+import ca.gc.aafc.dina.jpa.PredicateSupplier;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -98,7 +99,7 @@ public class DefaultDinaService<E extends DinaEntity> implements DinaService<E> 
   @Override
   public <T> List<T> findAll(
     @NonNull Class<T> entityClass,
-    @NonNull DinaService.DinaPredicateSupplier<T> where,
+    @NonNull PredicateSupplier<T> where,
     BiFunction<CriteriaBuilder, Root<T>, List<Order>> orderBy,
     int startIndex,
     int maxResult
@@ -124,7 +125,7 @@ public class DefaultDinaService<E extends DinaEntity> implements DinaService<E> 
   @Override
   public <T> Long getResourceCount(
     @NonNull Class<T> entityClass,
-    @NonNull DinaService.DinaPredicateSupplier<T> predicateSupplier
+    @NonNull PredicateSupplier<T> predicateSupplier
   ) {
     return baseDAO.getResourceCount(entityClass, predicateSupplier);
   }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DefaultDinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DefaultDinaService.java
@@ -107,7 +107,7 @@ public class DefaultDinaService<E extends DinaEntity> implements DinaService<E> 
     CriteriaBuilder criteriaBuilder = baseDAO.getCriteriaBuilder();
     CriteriaQuery<T> criteria = criteriaBuilder.createQuery(entityClass);
     Root<T> root = criteria.from(entityClass);
-    Predicate[] predicates = where.supply(criteriaBuilder, root, baseDAO.createWithEntityManager(m -> m));
+    Predicate[] predicates = baseDAO.buildPredicateFromSupplier(where, criteriaBuilder, root);
     criteria.where(predicates).select(root);
     if (orderBy != null) {
       criteria.orderBy(orderBy.apply(criteriaBuilder, root));

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DefaultDinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DefaultDinaService.java
@@ -141,7 +141,9 @@ public class DefaultDinaService<E extends DinaEntity> implements DinaService<E> 
     @NonNull Class<T> entityClass,
     @NonNull BiFunction<CriteriaBuilder, Root<T>, Predicate[]> predicateSupplier
   ) {
-    return baseDAO.getResourceCount(entityClass, predicateSupplier);
+    return getResourceCount(
+      entityClass,
+      (criteriaBuilder, root, em) -> predicateSupplier.apply(criteriaBuilder, root));
   }
 
   /**

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DefaultDinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DefaultDinaService.java
@@ -14,6 +14,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Service class for database interactions with a {@link DinaEntity}.
@@ -64,14 +65,13 @@ public class DefaultDinaService<E extends DinaEntity> implements DinaService<E> 
   }
 
   /**
-   * Returns a list of Entities of a given class restricted by the predicates returned by a given
-   * function.
+   * Returns a list of Entities of a given class restricted by the predicates returned by a given function.
    *
    * @param entityClass - entity class to query cannot be null
    * @param where       - function to return the predicates cannot be null
    * @param orderBy     - function to return the sorting criteria can be null
    * @param startIndex  - position of first result to retrieve
-   * @param maxResult   - maximun number of results to return
+   * @param maxResult   - maximum number of results to return
    * @return list of entities
    */
   @Override
@@ -85,12 +85,67 @@ public class DefaultDinaService<E extends DinaEntity> implements DinaService<E> 
     CriteriaBuilder criteriaBuilder = baseDAO.getCriteriaBuilder();
     CriteriaQuery<T> criteria = criteriaBuilder.createQuery(entityClass);
     Root<T> root = criteria.from(entityClass);
+    Predicate[] predicates = where.apply(criteriaBuilder, root);
+    applySortAndFilters(orderBy, criteriaBuilder, criteria, root, predicates);
+    return baseDAO.resultListFromCriteria(criteria, startIndex, maxResult);
+  }
 
-    criteria.where(where.apply(criteriaBuilder, root)).select(root);
+  /**
+   * Returns a list of Entities of a given class restricted by the predicates returned by a given function.
+   *
+   * @param entityClass - entity class to query cannot be null
+   * @param where       - function to return the predicates cannot be null
+   * @param orderBy     - function to return the sorting criteria can be null
+   * @param startIndex  - position of first result to retrieve
+   * @param maxResult   - maximum number of results to return
+   * @return list of entities
+   */
+  @Override
+  public <T> List<T> findAll(
+    @NonNull Class<T> entityClass,
+    @NonNull Function<DinaFilterPackage, Predicate[]> where,
+    BiFunction<CriteriaBuilder, Root<T>, List<Order>> orderBy,
+    int startIndex,
+    int maxResult
+  ) {
+    CriteriaBuilder criteriaBuilder = baseDAO.getCriteriaBuilder();
+    CriteriaQuery<T> criteria = criteriaBuilder.createQuery(entityClass);
+    Root<T> root = criteria.from(entityClass);
+    Predicate[] predicates = where.apply(DinaFilterPackage.builder()
+      .criteriaBuilder(criteriaBuilder)
+      .root(root)
+      .em(baseDAO.createWithEntityManager(manager -> manager))
+      .build());
+    applySortAndFilters(orderBy, criteriaBuilder, criteria, root, predicates);
+    return baseDAO.resultListFromCriteria(criteria, startIndex, maxResult);
+  }
+
+  private <T> void applySortAndFilters(
+    BiFunction<CriteriaBuilder, Root<T>, List<Order>> orderBy,
+    CriteriaBuilder criteriaBuilder,
+    CriteriaQuery<T> criteria,
+    Root<T> root,
+    Predicate[] predicates
+  ) {
+    criteria.where(predicates).select(root);
     if (orderBy != null) {
       criteria.orderBy(orderBy.apply(criteriaBuilder, root));
     }
-    return baseDAO.resultListFromCriteria(criteria, startIndex, maxResult);
+  }
+
+  /**
+   * Returns the resource count from a given predicate supplier.
+   *
+   * @param entityClass       - entity class to query cannot be null
+   * @param predicateSupplier - function to return the predicates cannot be null
+   * @return resource count
+   */
+  @Override
+  public <T> Long getResourceCount(
+    @NonNull Class<T> entityClass,
+    @NonNull Function<DinaFilterPackage, Predicate[]> predicateSupplier
+  ) {
+    return baseDAO.getResourceCount(entityClass, predicateSupplier);
   }
 
   /**

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DinaService.java
@@ -1,14 +1,18 @@
 package ca.gc.aafc.dina.service;
 
 import ca.gc.aafc.dina.entity.DinaEntity;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NonNull;
 
+import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Order;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Service class to provide a interface to a datasource.
@@ -18,8 +22,8 @@ import java.util.function.BiFunction;
 public interface DinaService<E extends DinaEntity> {
 
   /**
-   * Creates and returns a given entity with is newly assigned id. the returned Entity should be
-   * returned in the state it was persisted.
+   * Creates and returns a given entity with is newly assigned id. the returned Entity should be returned in
+   * the state it was persisted.
    *
    * @param entity entity to create.
    * @return a given entity with is newly assigned id.
@@ -61,8 +65,7 @@ public interface DinaService<E extends DinaEntity> {
   <T> T getReferenceByNaturalId(Class<T> entityClass, Object naturalId);
 
   /**
-   * Returns a list of Entities of a given class restricted by the predicates returned by a given
-   * function.
+   * Returns a list of Entities of a given class restricted by the predicates returned by a given function.
    *
    * @param entityClass - entity class to query cannot be null
    * @param where       - function to return the predicates cannot be null
@@ -74,6 +77,24 @@ public interface DinaService<E extends DinaEntity> {
   <T> List<T> findAll(
     @NonNull Class<T> entityClass,
     @NonNull BiFunction<CriteriaBuilder, Root<T>, Predicate[]> where,
+    BiFunction<CriteriaBuilder, Root<T>, List<Order>> orderBy,
+    int startIndex,
+    int maxResult
+  );
+
+  /**
+   * Returns a list of Entities of a given class restricted by the predicates returned by a given function.
+   *
+   * @param entityClass - entity class to query cannot be null
+   * @param where       - function to return the predicates cannot be null
+   * @param orderBy     - function to return the sorting criteria can be null
+   * @param startIndex  - position of first result to retrieve
+   * @param maxResult   - maximun number of results to return
+   * @return list of entities
+   */
+  <T> List<T> findAll(
+    @NonNull Class<T> entityClass,
+    @NonNull Function<DinaFilterPackage, Predicate[]> where,
     BiFunction<CriteriaBuilder, Root<T>, List<Order>> orderBy,
     int startIndex,
     int maxResult
@@ -92,8 +113,28 @@ public interface DinaService<E extends DinaEntity> {
   );
 
   /**
+   * Returns the resource count from a given predicate supplier.
+   *
+   * @param entityClass       - entity class to query cannot be null
+   * @param predicateSupplier - function to return the predicates cannot be null
+   * @return resource count
+   */
+  <T> Long getResourceCount(
+    @NonNull Class<T> entityClass,
+    @NonNull Function<DinaFilterPackage, Predicate[]> predicateSupplier
+  );
+
+  /**
    * Check for the existence of a record by natural id.
    */
   boolean exists(Class<?> entityClass, Object naturalId);
+
+  @Builder
+  @Getter
+  class DinaFilterPackage {
+    private final CriteriaBuilder criteriaBuilder;
+    private final Root<?> root;
+    private final EntityManager em;
+  }
 
 }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DinaService.java
@@ -1,9 +1,9 @@
 package ca.gc.aafc.dina.service;
 
 import ca.gc.aafc.dina.entity.DinaEntity;
+import ca.gc.aafc.dina.jpa.PredicateSupplier;
 import lombok.NonNull;
 
-import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Order;
 import javax.persistence.criteria.Predicate;
@@ -91,7 +91,7 @@ public interface DinaService<E extends DinaEntity> {
    */
   <T> List<T> findAll(
     @NonNull Class<T> entityClass,
-    @NonNull DinaService.DinaPredicateSupplier<T> where,
+    @NonNull PredicateSupplier<T> where,
     BiFunction<CriteriaBuilder, Root<T>, List<Order>> orderBy,
     int startIndex,
     int maxResult
@@ -118,17 +118,12 @@ public interface DinaService<E extends DinaEntity> {
    */
   <T> Long getResourceCount(
     @NonNull Class<T> entityClass,
-    @NonNull DinaService.DinaPredicateSupplier<T> predicateSupplier
+    @NonNull PredicateSupplier<T> predicateSupplier
   );
 
   /**
    * Check for the existence of a record by natural id.
    */
   boolean exists(Class<?> entityClass, Object naturalId);
-
-  @FunctionalInterface
-  interface DinaPredicateSupplier<T> {
-    Predicate[] supply(CriteriaBuilder criteriaBuilder, Root<T> root, EntityManager em);
-  }
 
 }

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DinaService.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/service/DinaService.java
@@ -1,8 +1,6 @@
 package ca.gc.aafc.dina.service;
 
 import ca.gc.aafc.dina.entity.DinaEntity;
-import lombok.Builder;
-import lombok.Getter;
 import lombok.NonNull;
 
 import javax.persistence.EntityManager;
@@ -12,7 +10,6 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.util.List;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * Service class to provide a interface to a datasource.
@@ -94,7 +91,7 @@ public interface DinaService<E extends DinaEntity> {
    */
   <T> List<T> findAll(
     @NonNull Class<T> entityClass,
-    @NonNull Function<DinaFilterPackage, Predicate[]> where,
+    @NonNull DinaService.DinaPredicateSupplier<T> where,
     BiFunction<CriteriaBuilder, Root<T>, List<Order>> orderBy,
     int startIndex,
     int maxResult
@@ -121,7 +118,7 @@ public interface DinaService<E extends DinaEntity> {
    */
   <T> Long getResourceCount(
     @NonNull Class<T> entityClass,
-    @NonNull Function<DinaFilterPackage, Predicate[]> predicateSupplier
+    @NonNull DinaService.DinaPredicateSupplier<T> predicateSupplier
   );
 
   /**
@@ -129,12 +126,9 @@ public interface DinaService<E extends DinaEntity> {
    */
   boolean exists(Class<?> entityClass, Object naturalId);
 
-  @Builder
-  @Getter
-  class DinaFilterPackage {
-    private final CriteriaBuilder criteriaBuilder;
-    private final Root<?> root;
-    private final EntityManager em;
+  @FunctionalInterface
+  interface DinaPredicateSupplier<T> {
+    Predicate[] supply(CriteriaBuilder criteriaBuilder, Root<T> root, EntityManager em);
   }
 
 }


### PR DESCRIPTION
Expand the dina interface to allow access to predicate building with the entity manager.

This is a requirement of Rsql.

We tighten up definition of what actually can supply predicates to the dina service with a new functional interface.

```
  @FunctionalInterface
  interface DinaPredicateSupplier<T> {
    Predicate[] supply(CriteriaBuilder criteriaBuilder, Root<T> root, EntityManager em);
  }
```

We over load two additional methods and chain them up to existing methods using our new interface.

Test should verify everything is working as expected.