### PR TITLE
27057 Allow ManagedAttributeValueValidator to use ValidationContext

### DIFF
--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/BaseDAO.java
@@ -142,15 +142,11 @@ public class BaseDAO {
     CriteriaQuery<T> criteria = criteriaBuilder.createQuery(clazz);
     Root<T> root = criteria.from(clazz);
 
-    Predicate whereClause = null;
-    for(Pair<String, Object> propVal : propertiesAndValue) {
-      Predicate clause = criteriaBuilder.equal(root.get(propVal.getKey()), propVal.getValue());
-      whereClause = whereClause == null ? clause : criteriaBuilder.and(whereClause, clause);
-    }
+    Predicate whereClause =
+        PredicateHelper.appendPropertiesEqual(null, criteriaBuilder, root, propertiesAndValue);
 
     criteria.where(whereClause);
     criteria.select(root);
-
     TypedQuery<T> query = entityManager.createQuery(criteria);
     try {
       return query.getSingleResult();

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/PredicateHelper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/PredicateHelper.java
@@ -1,0 +1,37 @@
+package ca.gc.aafc.dina.jpa;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.util.List;
+
+/**
+ * Utility class to help manipulating {@link Predicate}
+ */
+public final class PredicateHelper {
+
+  private PredicateHelper(){}
+
+  /**
+   * Add to the provided Predicate (if provided otherwise a new one will be created) clauses for each pair provided (AND separated).
+   * @param currentPredicate current predicate or null to build a new one
+   * @param criteriaBuilder
+   * @param root
+   * @param propertiesAndValue
+   * @return
+   */
+  public static Predicate appendPropertiesEqual(Predicate currentPredicate,
+      CriteriaBuilder criteriaBuilder, Root<?> root,
+      List<Pair<String, Object>> propertiesAndValue) {
+
+    Predicate updatedPredicate = currentPredicate;
+    for (Pair<String, Object> propVal : propertiesAndValue) {
+      Predicate clause = criteriaBuilder.equal(root.get(propVal.getKey()), propVal.getValue());
+      updatedPredicate =
+          updatedPredicate == null ? clause : criteriaBuilder.and(updatedPredicate, clause);
+    }
+    return updatedPredicate;
+  }
+}

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/PredicateHelper.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/jpa/PredicateHelper.java
@@ -12,7 +12,8 @@ import java.util.List;
  */
 public final class PredicateHelper {
 
-  private PredicateHelper(){}
+  private PredicateHelper() {
+  }
 
   /**
    * Add to the provided Predicate (if provided otherwise a new one will be created) clauses for each pair provided (AND separated).

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/validation/ManagedAttributeValueValidator.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/validation/ManagedAttributeValueValidator.java
@@ -27,6 +27,7 @@ public class ManagedAttributeValueValidator<E extends ManagedAttribute> implemen
 
   private static final String MANAGED_ATTRIBUTE_INVALID_VALUE = "managedAttribute.value.invalid";
   private static final String MANAGED_ATTRIBUTE_INVALID_KEY = "managedAttribute.key.invalid";
+  private static final String MANAGED_ATTRIBUTE_INVALID_KEY_CONTEXT = "managedAttribute.keyContext.invalid";
   private static final Pattern INTEGER_PATTERN = Pattern.compile("\\d+");
 
   private final ManagedAttributeService<E> dinaService;
@@ -117,7 +118,14 @@ public class ManagedAttributeValueValidator<E extends ManagedAttribute> implemen
 
     Collection<?> difference = CollectionUtils.disjunction(attributesAndValues.keySet(), attributesPerKey.keySet());
     if (!difference.isEmpty()) {
-      errors.reject(MANAGED_ATTRIBUTE_INVALID_KEY, getMessageForKey(MANAGED_ATTRIBUTE_INVALID_KEY, difference.stream().findFirst().get()));
+      if( validationContext == null) {
+        errors.reject(MANAGED_ATTRIBUTE_INVALID_KEY,
+            getMessageForKey(MANAGED_ATTRIBUTE_INVALID_KEY, difference.stream().findFirst().get()));
+      }
+      else {
+        errors.reject(MANAGED_ATTRIBUTE_INVALID_KEY_CONTEXT,
+            getMessageForKey(MANAGED_ATTRIBUTE_INVALID_KEY_CONTEXT, difference.stream().findFirst().get(), validationContext.toString()));
+      }
     }
 
     attributesPerKey.forEach((key, ma) -> {

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/validation/ManagedAttributeValueValidator.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/validation/ManagedAttributeValueValidator.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class ManagedAttributeValueValidator<E extends ManagedAttribute> implements Validator {
@@ -98,9 +99,21 @@ public class ManagedAttributeValueValidator<E extends ManagedAttribute> implemen
     ValidationErrorsHelper.errorsToValidationException(errors);
   }
 
+  /**
+   * Find the concrete {@link ManagedAttribute} mapping based on a set of keys.
+   * By default {@link ValidationContext} is ignored but a subclass can override this function
+   * to make use of it if the uniqueness of the managed attribute uses more columns than the key.
+   *
+   * @param keys
+   * @param validationContext
+   * @return
+   */
+  protected Map<String, E> findAttributesForValidation(Set<String> keys, ValidationContext validationContext) {
+    return dinaService.findAttributesForKeys(keys);
+  }
 
   private void validateElements(Map<String, String> attributesAndValues, Errors errors, ValidationContext validationContext) {
-    Map<String, E> attributesPerKey = dinaService.findAttributesForKeys(attributesAndValues.keySet());
+    Map<String, E> attributesPerKey = findAttributesForValidation(attributesAndValues.keySet(), validationContext);
 
     Collection<?> difference = CollectionUtils.disjunction(attributesAndValues.keySet(), attributesPerKey.keySet());
     if (!difference.isEmpty()) {

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/validation/ManagedAttributeValueValidator.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/validation/ManagedAttributeValueValidator.java
@@ -124,13 +124,13 @@ public class ManagedAttributeValueValidator<E extends ManagedAttribute> implemen
 
     Collection<?> difference = CollectionUtils.disjunction(attributesAndValues.keySet(), attributesPerKey.keySet());
     if (!difference.isEmpty()) {
-      if( validationContext == null) {
+      if (validationContext == null) {
         errors.reject(MANAGED_ATTRIBUTE_INVALID_KEY,
             getMessageForKey(MANAGED_ATTRIBUTE_INVALID_KEY, difference.stream().findFirst().get()));
-      }
-      else {
+      } else {
         errors.reject(MANAGED_ATTRIBUTE_INVALID_KEY_CONTEXT,
-            getMessageForKey(MANAGED_ATTRIBUTE_INVALID_KEY_CONTEXT, difference.stream().findFirst().get(), validationContext.toString()));
+            getMessageForKey(MANAGED_ATTRIBUTE_INVALID_KEY_CONTEXT,
+                difference.stream().findFirst().get(), validationContext.toString()));
       }
     }
 

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/validation/ManagedAttributeValueValidator.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/validation/ManagedAttributeValueValidator.java
@@ -53,6 +53,12 @@ public class ManagedAttributeValueValidator<E extends ManagedAttribute> implemen
     validateElements((Map<String, String>) target, errors, null);
   }
 
+  @SuppressWarnings("unchecked") // We check with checkIncomingParameter()
+  public void validate(@NonNull Object target, @NonNull Errors errors, ValidationContext context) {
+    checkIncomingParameter(target);
+    validateElements((Map<String, String>) target, errors, context);
+  }
+
   /**
    * Same as {@link #validate(DinaEntity, Map, ValidationContext)} but without a {@link ValidationContext}.
    * @param entity

--- a/dina-base-api/src/main/java/ca/gc/aafc/dina/validation/ValidationContext.java
+++ b/dina-base-api/src/main/java/ca/gc/aafc/dina/validation/ValidationContext.java
@@ -4,4 +4,11 @@ package ca.gc.aafc.dina.validation;
  * Marker Interface used to send some context to a validation
  */
 public interface ValidationContext {
+
+  /**
+   * Value of the context as an Object.
+   * Can be used to add to a JPA Criteria.
+   * @return
+   */
+  Object getValue();
 }

--- a/dina-base-api/src/main/resources/base-validation-messages.properties
+++ b/dina-base-api/src/main/resources/base-validation-messages.properties
@@ -2,3 +2,4 @@ multilingual.description.unsupported=Language "{0}" is not supported
 
 managedAttribute.value.invalid=Value "{0}" is invalid for key {1}
 managedAttribute.key.invalid="{0}" unknown managed attribute key
+managedAttribute.keyContext.invalid="{0}" unknown managed attribute key for context {1}

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/service/ManagedAttributeServiceIT.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/service/ManagedAttributeServiceIT.java
@@ -36,6 +36,7 @@ import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -122,10 +123,28 @@ public class ManagedAttributeServiceIT {
           }
           return true;
         }
+
+        /**
+         * Override this method to allow uniqueness by key/component (instead of only key).
+         * @param keys
+         * @param validationContext
+         * @return
+         */
+        @Override
+        protected Map<String, TestManagedAttribute> findAttributesForValidation(
+            Set<String> keys, ValidationContext validationContext) {
+          return dinaService.findAttributesForKeys(keys, Pair.of("component",
+               validationContext.getValue()));
+        }
       };
     }
   }
 
+  /**
+   * Test implementation of a {@link ManagedAttribute}.
+   * Since it's running on H2 the uniqueness if not really define so the test will assume
+   * it is by key or key/component depending on the purpose of the test.
+   */
   @Data
   @Builder
   @Entity
@@ -147,6 +166,9 @@ public class ManagedAttributeServiceIT {
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     private MultilingualDescription multilingualDescription;
+
+    // matches XYZValidationContext toString
+    private String component;
   }
 
   @Data
@@ -164,7 +186,12 @@ public class ManagedAttributeServiceIT {
   }
 
   public enum XYZValidationContext implements ValidationContext {
-    X, Y, Z
+    X, Y, Z;
+
+    @Override
+    public Object getValue() {
+      return toString();
+    }
   }
 
 }

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/validation/ManagedAttributeValueValidatorTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/validation/ManagedAttributeValueValidatorTest.java
@@ -234,6 +234,23 @@ public class ManagedAttributeValueValidatorTest {
     validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav, ManagedAttributeServiceIT.XYZValidationContext.X);
   }
 
+  @Test
+  void validate_duplicatedKeysDifferentContext_ValidationWorks() {
+    TestManagedAttribute testManagedAttribute1 = newTestManagedAttribute(ManagedAttribute.ManagedAttributeType.BOOL);
+    testManagedAttribute1.setName("name1");
+    testManagedAttribute1.setComponent(ManagedAttributeServiceIT.XYZValidationContext.X.toString());
+    testManagedAttribute1 = testManagedAttributeService.createAndFlush(testManagedAttribute1);
+
+    // same name but on a different component
+    TestManagedAttribute testManagedAttribute2 = newTestManagedAttribute(ManagedAttribute.ManagedAttributeType.BOOL);
+    testManagedAttribute2.setName("name1");
+    testManagedAttribute2.setComponent(ManagedAttributeServiceIT.XYZValidationContext.Y.toString());
+    testManagedAttributeService.createAndFlush(testManagedAttribute2);
+
+    Map<String, String> mav = Map.of(testManagedAttribute1.getKey(), "true");
+    validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav, ManagedAttributeServiceIT.XYZValidationContext.X);
+  }
+
   private TestManagedAttribute newTestManagedAttribute(ManagedAttribute.ManagedAttributeType type) {
     return ManagedAttributeServiceIT.TestManagedAttribute.builder().
         name(RandomStringUtils.randomAlphabetic(6))

--- a/dina-base-api/src/test/java/ca/gc/aafc/dina/validation/ManagedAttributeValueValidatorTest.java
+++ b/dina-base-api/src/test/java/ca/gc/aafc/dina/validation/ManagedAttributeValueValidatorTest.java
@@ -61,7 +61,7 @@ public class ManagedAttributeValueValidatorTest {
         newTestManagedAttribute(ManagedAttribute.ManagedAttributeType.DATE));
 
     Map<String, String> mav = Map.of(testManagedAttribute.getKey(), value);
-    assertThrows(ValidationException.class, () -> validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav));
+    assertThrows(ValidationException.class, () -> validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav, ManagedAttributeServiceIT.XYZValidationContext.X));
   }
 
   @Test
@@ -69,6 +69,7 @@ public class ManagedAttributeValueValidatorTest {
     testManagedAttribute = ManagedAttributeServiceIT.TestManagedAttribute.builder().
       name(RandomStringUtils.randomAlphabetic(6))
       .managedAttributeType(ManagedAttribute.ManagedAttributeType.STRING)
+      .component(ManagedAttributeServiceIT.XYZValidationContext.X.toString())
       .build();
     testManagedAttributeService.create(testManagedAttribute);
 
@@ -78,39 +79,43 @@ public class ManagedAttributeValueValidatorTest {
 
   @Test
   void validate_WhenValidIntegerType_NoExceptionThrown() {
-    testManagedAttribute = ManagedAttributeServiceIT.TestManagedAttribute.builder().
-      name(RandomStringUtils.randomAlphabetic(6))
-      .managedAttributeType(ManagedAttribute.ManagedAttributeType.INTEGER)
-      .build();
+    testManagedAttribute = ManagedAttributeServiceIT.TestManagedAttribute.builder()
+        .name(RandomStringUtils.randomAlphabetic(6))
+        .managedAttributeType(ManagedAttribute.ManagedAttributeType.INTEGER)
+        .component(ManagedAttributeServiceIT.XYZValidationContext.X.toString())
+        .build();
     testManagedAttributeService.create(testManagedAttribute);
 
     Map<String, String> mav = Map.of(testManagedAttribute.getKey(), "1");
-    validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav);
+    validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav, ManagedAttributeServiceIT.XYZValidationContext.X);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"1.2", "", "  ", "\t", "\n", "a"})
   void validate_WhenInvalidIntegerType_ExceptionThrown(String value) {
-    testManagedAttribute = ManagedAttributeServiceIT.TestManagedAttribute.builder().
-      name(RandomStringUtils.randomAlphabetic(6))
-      .managedAttributeType(ManagedAttribute.ManagedAttributeType.INTEGER)
-      .build();
+    testManagedAttribute = ManagedAttributeServiceIT.TestManagedAttribute.builder()
+        .name(RandomStringUtils.randomAlphabetic(6))
+        .managedAttributeType(ManagedAttribute.ManagedAttributeType.INTEGER)
+        .component(ManagedAttributeServiceIT.XYZValidationContext.X.toString())
+        .build();
     testManagedAttributeService.create(testManagedAttribute);
 
     Map<String, String> mav = Map.of(testManagedAttribute.getKey(), value);
-    assertThrows(ValidationException.class, () -> validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav));
+    assertThrows(ValidationException.class, () ->
+        validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav, ManagedAttributeServiceIT.XYZValidationContext.X));
   }
 
   @Test
   void validate_WhenInvalidIntegerTypeExceptionThrown() {
-    testManagedAttribute = ManagedAttributeServiceIT.TestManagedAttribute.builder().
-        name(RandomStringUtils.randomAlphabetic(6))
+    testManagedAttribute = ManagedAttributeServiceIT.TestManagedAttribute.builder()
+        .name(RandomStringUtils.randomAlphabetic(6))
+        .component(ManagedAttributeServiceIT.XYZValidationContext.X.toString())
         .managedAttributeType(ManagedAttribute.ManagedAttributeType.INTEGER)
         .build();
     testManagedAttributeService.create(testManagedAttribute);
     Map<String, String> mav = Map.of(testManagedAttribute.getKey(), "1.2");
     assertThrows(ValidationException.class,
-        () -> validatorUnderTest.validate(Department.builder().uuid(UUID.randomUUID()).build(), mav));
+        () -> validatorUnderTest.validate(Department.builder().uuid(UUID.randomUUID()).build(), mav, ManagedAttributeServiceIT.XYZValidationContext.X));
   }
 
   @Test
@@ -118,40 +123,41 @@ public class ManagedAttributeValueValidatorTest {
     testManagedAttribute = ManagedAttributeServiceIT.TestManagedAttribute.builder().
         name(RandomStringUtils.randomAlphabetic(6))
         .managedAttributeType(ManagedAttribute.ManagedAttributeType.INTEGER)
+        .component(ManagedAttributeServiceIT.XYZValidationContext.X.toString())
         .failValidateValue(true)
         .build();
     testManagedAttributeService.create(testManagedAttribute);
     Map<String, String> mav = Map.of(testManagedAttribute.getKey(), "2");
     assertThrows(ValidationException.class,
-        () -> validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav));
+        () -> validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav, ManagedAttributeServiceIT.XYZValidationContext.X));
   }
 
   @Test
   public void assignedValueContainedInAcceptedValues_validationPasses() {
     testManagedAttribute = ManagedAttributeServiceIT.TestManagedAttribute.builder()
         .name("My special Attribute")
+        .component(ManagedAttributeServiceIT.XYZValidationContext.X.toString())
         .managedAttributeType(ManagedAttribute.ManagedAttributeType.STRING)
         .acceptedValues(new String[]{"val1", "val2"}).build();
     testManagedAttributeService.create(testManagedAttribute);
 
-    Map<String, String> mav = Map.of(testManagedAttribute.getKey(), "val1");
-
-    Errors errors = new BeanPropertyBindingResult(mav, "mav");
-    validatorUnderTest.validate(mav, errors);
-    assertFalse(errors.hasErrors());
+    Map<String, String> mav = Map.of(testManagedAttribute.getKey(), "val2");
+    validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav, ManagedAttributeServiceIT.XYZValidationContext.X);
   }
 
   @Test
   public void assignedValueNotContainedInAcceptedValues_validationFails() {
-    testManagedAttribute = ManagedAttributeServiceIT.TestManagedAttribute.builder().
-      name("key2").managedAttributeType(ManagedAttribute.ManagedAttributeType.STRING)
+    testManagedAttribute = ManagedAttributeServiceIT.TestManagedAttribute.builder()
+        .name("key2")
+        .managedAttributeType(ManagedAttribute.ManagedAttributeType.STRING)
+        .component(ManagedAttributeServiceIT.XYZValidationContext.X.toString())
         .acceptedValues(new String[]{"val1", "val2"}).build();
     testManagedAttributeService.create(testManagedAttribute);
 
     Map<String, String> mav = Map.of(testManagedAttribute.getKey(), "val3");
 
     Errors errors = new BeanPropertyBindingResult(mav, "mav");
-    validatorUnderTest.validate(mav, errors);
+    validatorUnderTest.validate(mav, errors, ManagedAttributeServiceIT.XYZValidationContext.X);
     assertEquals(1, errors.getErrorCount());
 
     assertTrue(errors.getAllErrors().get(0).getDefaultMessage().contains("val3"));
@@ -160,14 +166,15 @@ public class ManagedAttributeValueValidatorTest {
   @Test
   public void assignedKeyDoesNotExist_ValidationExceptionThrown() {
     Map<String, String> mav = Map.of("key_x", "val3");
-    assertThrows(ValidationException.class, () -> validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav));
+    assertThrows(ValidationException.class, () ->
+        validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav, ManagedAttributeServiceIT.XYZValidationContext.X));
   }
 
   @Test
   public void validate_whenEmpty_NoErrors() {
     Map<String, String> mav = Map.of();
     Errors errors = new BeanPropertyBindingResult(mav, "mav");
-    validatorUnderTest.validate(mav, errors);
+    validatorUnderTest.validate(mav, errors, ManagedAttributeServiceIT.XYZValidationContext.X);
     assertFalse(errors.hasErrors());
   }
 
@@ -191,14 +198,16 @@ public class ManagedAttributeValueValidatorTest {
 
   @Test
   void validate_NonDinaEntity_NoErrors() {
-    testManagedAttribute = testManagedAttributeService.create(ManagedAttributeServiceIT.TestManagedAttribute.builder()
-    .name(RandomStringUtils.randomAlphabetic(6))
-    .managedAttributeType(ManagedAttribute.ManagedAttributeType.DATE)
-    .build());
+    testManagedAttribute = testManagedAttributeService.create(
+        ManagedAttributeServiceIT.TestManagedAttribute.builder()
+            .name(RandomStringUtils.randomAlphabetic(6))
+            .managedAttributeType(ManagedAttribute.ManagedAttributeType.DATE)
+            .component(ManagedAttributeServiceIT.XYZValidationContext.X.toString()).build());
 
-  Map<String, String> mav = Map.of(testManagedAttribute.getKey(), LocalDate.now().toString());
-  
-  validatorUnderTest.validate(ENTITY_PLACEHOLDER.getUuid().toString(), ENTITY_PLACEHOLDER, mav, ManagedAttributeServiceIT.XYZValidationContext.X);
+    Map<String, String> mav = Map.of(testManagedAttribute.getKey(), LocalDate.now().toString());
+
+    validatorUnderTest.validate(ENTITY_PLACEHOLDER.getUuid().toString(), ENTITY_PLACEHOLDER, mav,
+        ManagedAttributeServiceIT.XYZValidationContext.X);
   }
 
   @Test
@@ -216,12 +225,13 @@ public class ManagedAttributeValueValidatorTest {
   @ParameterizedTest
   @ValueSource(strings = {"", "off", "TRUE"})
   void validate_WhenInvalidBoolType_ExceptionThrown(String value) {
-    testManagedAttribute = testManagedAttributeService.create(ManagedAttributeServiceIT.TestManagedAttribute.builder().
-        name(RandomStringUtils.randomAlphabetic(6))
+    testManagedAttribute = testManagedAttributeService.create(ManagedAttributeServiceIT.TestManagedAttribute.builder()
+        .name(RandomStringUtils.randomAlphabetic(6))
+        .component(ManagedAttributeServiceIT.XYZValidationContext.X.toString())
         .managedAttributeType(ManagedAttribute.ManagedAttributeType.BOOL)
         .build());
     Map<String, String> mav = Map.of(testManagedAttribute.getKey(), value);
-    assertThrows(ValidationException.class, () -> validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav));
+    assertThrows(ValidationException.class, () -> validatorUnderTest.validate(ENTITY_PLACEHOLDER, mav, ManagedAttributeServiceIT.XYZValidationContext.X));
   }
 
   @ParameterizedTest
@@ -255,6 +265,7 @@ public class ManagedAttributeValueValidatorTest {
     return ManagedAttributeServiceIT.TestManagedAttribute.builder().
         name(RandomStringUtils.randomAlphabetic(6))
         .managedAttributeType(type)
+        .component(ManagedAttributeServiceIT.XYZValidationContext.X.toString())
         .multilingualDescription(MultilingualDescription.builder()
             .descriptions(ImmutableList.of(
                 MultilingualDescription.MultilingualPair.builder()


### PR DESCRIPTION
Added findAttributesForValidation that a subclass can override to make use of the validation context.