### PR TITLE
28110 Set default to utf8 on jsonapi encoding for restassured

### DIFF
--- a/dina-test-support/src/main/java/ca/gc/aafc/dina/testsupport/BaseRestAssuredTest.java
+++ b/dina-test-support/src/main/java/ca/gc/aafc/dina/testsupport/BaseRestAssuredTest.java
@@ -2,6 +2,8 @@ package ca.gc.aafc.dina.testsupport;
 
 import static io.restassured.RestAssured.given;
 
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,6 +64,10 @@ public class BaseRestAssuredTest {
   private RequestSpecification newRequest() {
     return given()
       .header(CRNK_HEADER)
+      .config(RestAssured.config()
+              .encoderConfig(EncoderConfig.encoderConfig()
+                      .defaultCharsetForContentType("UTF-8", JSON_API_CONTENT_TYPE)
+                      .defaultCharsetForContentType("UTF-8", JSON_PATCH_CONTENT_TYPE)))
       .port(testPort)
       .basePath(basePath);
   }

--- a/dina-test-support/src/test/java/ca/gc/aafc/dina/testsupport/BaseRestAssuredTestIT.java
+++ b/dina-test-support/src/test/java/ca/gc/aafc/dina/testsupport/BaseRestAssuredTestIT.java
@@ -26,7 +26,8 @@ public class BaseRestAssuredTestIT extends BaseRestAssuredTest {
    */
   @Test
 	public void baseClass_OnCRUDOperations_ExpectedReturnCodesReturned() {
-    CrnkTestData testData = CrnkTestData.builder().note("note").build();
+    // test with UTF-8 character to make sure it's fine
+    CrnkTestData testData = CrnkTestData.builder().note("note en français").build();
 
     ValidatableResponse postResponse = sendPost(
       JsonAPITestHelper.toJsonAPIMap(RESOURCE_PATH, testData));


### PR DESCRIPTION
Configure restassured to use utf8 on jsonapi content type