### PR TITLE
31676 Replace nullable and nonnull annotations

### DIFF
--- a/dina-base-api/src/main/resources/checkstyle.xml
+++ b/dina-base-api/src/main/resources/checkstyle.xml
@@ -273,7 +273,9 @@ limitations under the License.
         com.google.common.collect.ImmutableList,
         com.google.common.collect.ImmutableMap,
         com.google.common.collect.ImmutableSet,
-        com.google.common.base.Optional
+        com.google.common.base.Optional,
+        javax.annotation.Nullable,
+        javax.annotation.Nonnull
         "/>
       </module>
       <module name="RedundantImport">


### PR DESCRIPTION
edu.umd.cs.findbugs.annotations should be used instead